### PR TITLE
Fix query for ConnectionNodesLength

### DIFF
--- a/threedi_modelchecker/checks/other.py
+++ b/threedi_modelchecker/checks/other.py
@@ -255,7 +255,7 @@ class ConnectionNodesLength(BaseCheck):
         start_node = aliased(models.ConnectionNode)
         end_node = aliased(models.ConnectionNode)
         q = Query(
-            self.table
+            self.column.class_
         ).join(
             start_node, self.start_node
         ).join(


### PR DESCRIPTION
closes https://github.com/nens/ThreeDiToolbox/issues/497

sqlalchemy 1.1.18 doesn't support this query but sqlalchemy 1.3.1 does. This fixes the query for sqlalchemy 1.1.18

