### PR TITLE
Add management=True to geometry columns

### DIFF
--- a/threedi_modelchecker/threedi_model/models.py
+++ b/threedi_modelchecker/threedi_model/models.py
@@ -25,7 +25,7 @@ class Lateral2D(Base):
     type = Column(IntegerEnum(constants.Later2dType), nullable=False)
     the_geom = Column(
         Geometry(geometry_type="POINT", srid=4326, spatial_index=True, management=True),
-        nullable=False
+        nullable=False,
     )
     timeseries = Column(Text, nullable=False)
 
@@ -38,8 +38,10 @@ class BoundaryConditions2D(Base):
     timeseries = Column(Text, nullable=False)
     boundary_type = Column(IntegerEnum(constants.BoundaryType), nullable=False)
     the_geom = Column(
-        Geometry(geometry_type="LINESTRING", srid=4326, spatial_index=True, management=True),
-        nullable=False
+        Geometry(
+            geometry_type="LINESTRING", srid=4326, spatial_index=True, management=True
+        ),
+        nullable=False,
     )
 
 
@@ -51,7 +53,8 @@ class CalculationPoint(Base):
     user_ref = Column(String(80), nullable=False)
     calc_type = Column(Integer, nullable=False)
     the_geom = Column(
-        Geometry(geometry_type="POINT", srid=4326, spatial_index=True, management=True), nullable=False
+        Geometry(geometry_type="POINT", srid=4326, spatial_index=True, management=True),
+        nullable=False,
     )
 
 
@@ -157,7 +160,9 @@ class Floodfill(Base):
     __tablename__ = "v2_floodfill"
     id = Column(Integer, primary_key=True)
     waterlevel = Column(Float)
-    the_geom = Column(Geometry(geometry_type="POINT", srid=4326, spatial_index=True, management=True))
+    the_geom = Column(
+        Geometry(geometry_type="POINT", srid=4326, spatial_index=True, management=True)
+    )
 
 
 class Interflow(Base):
@@ -179,7 +184,10 @@ class PumpedDrainageArea(Base):
     name = Column(String(64), nullable=False)
     code = Column(String(100), nullable=False)
     the_geom = Column(
-        Geometry(geometry_type="POLYGON", srid=4326, spatial_index=True, management=True), nullable=False
+        Geometry(
+            geometry_type="POLYGON", srid=4326, spatial_index=True, management=True
+        ),
+        nullable=False,
     )
 
 
@@ -221,8 +229,10 @@ class Surface(Base):
         Integer, ForeignKey(SurfaceParameter.__tablename__ + ".id"), nullable=False
     )
     the_geom = Column(
-        Geometry(geometry_type="POLYGON", srid=4326, spatial_index=True, management=True),
-        nullable=False
+        Geometry(
+            geometry_type="POLYGON", srid=4326, spatial_index=True, management=True
+        ),
+        nullable=False,
     )
 
 
@@ -266,8 +276,10 @@ class GridRefinement(Base):
     display_name = Column(String(255), nullable=False)
     refinement_level = Column(Integer, nullable=False)
     the_geom = Column(
-        Geometry(geometry_type="LINESTRING", srid=4326, spatial_index=True, management=True),
-        nullable=False
+        Geometry(
+            geometry_type="LINESTRING", srid=4326, spatial_index=True, management=True
+        ),
+        nullable=False,
     )
     code = Column(String(100), nullable=False)
 
@@ -278,7 +290,11 @@ class GridRefinementArea(Base):
     display_name = Column(String(255), nullable=False)
     refinement_level = Column(Integer, nullable=False)
     code = Column(String(100), nullable=False)
-    the_geom = Column(Geometry(geometry_type="POLYGON", srid=4326, spatial_index=True, management=True))
+    the_geom = Column(
+        Geometry(
+            geometry_type="POLYGON", srid=4326, spatial_index=True, management=True
+        )
+    )
 
 
 class CrossSectionDefinition(Base):
@@ -297,10 +313,12 @@ class ConnectionNode(Base):
     initial_waterlevel = Column(Float)
     the_geom = Column(
         Geometry(geometry_type="POINT", srid=4326, spatial_index=True, management=True),
-        nullable=False
+        nullable=False,
     )
     the_geom_linestring = Column(
-        Geometry(geometry_type="LINESTRING", srid=4326, spatial_index=False, management=True)
+        Geometry(
+            geometry_type="LINESTRING", srid=4326, spatial_index=False, management=True
+        )
     )
     code = Column(String(100), nullable=False)
 
@@ -487,7 +505,9 @@ class Channel(Base):
     dist_calc_points = Column(Float)
     zoom_category = Column(IntegerEnum(constants.ZoomCategories))
     the_geom = Column(
-        Geometry(geometry_type="LINESTRING", srid=4326, spatial_index=True, management=True),
+        Geometry(
+            geometry_type="LINESTRING", srid=4326, spatial_index=True, management=True
+        ),
         nullable=False,
     )
 
@@ -519,7 +539,9 @@ class Windshielding(Base):
     southwest = Column(Float)
     west = Column(Float)
     northwest = Column(Float)
-    the_geom = Column(Geometry(geometry_type="POINT", srid=4326, spatial_index=True, management=True))
+    the_geom = Column(
+        Geometry(geometry_type="POINT", srid=4326, spatial_index=True, management=True)
+    )
     channel_id = Column(
         Integer, ForeignKey(Channel.__tablename__ + ".id"), nullable=False
     )
@@ -535,7 +557,7 @@ class CrossSectionLocation(Base):
     bank_level = Column(Float)
     the_geom = Column(
         Geometry(geometry_type="POINT", srid=4326, spatial_index=True, management=True),
-        nullable=False
+        nullable=False,
     )
     channel_id = Column(
         Integer, ForeignKey(Channel.__tablename__ + ".id"), nullable=False
@@ -603,7 +625,9 @@ class Culvert(Base):
     invert_level_start_point = Column(Float, nullable=False)
     invert_level_end_point = Column(Float, nullable=False)
     the_geom = Column(
-        Geometry(geometry_type="LINESTRING", srid=4326, spatial_index=True, management=True),
+        Geometry(
+            geometry_type="LINESTRING", srid=4326, spatial_index=True, management=True
+        ),
         nullable=False,
     )
 
@@ -630,7 +654,11 @@ class Culvert(Base):
 class DemAverageArea(Base):
     __tablename__ = "v2_dem_average_area"
     id = Column(Integer, primary_key=True)
-    the_geom = Column(Geometry(geometry_type="POLYGON", srid=4326, spatial_index=True, management=True))
+    the_geom = Column(
+        Geometry(
+            geometry_type="POLYGON", srid=4326, spatial_index=True, management=True
+        )
+    )
 
 
 class Weir(Base):
@@ -711,10 +739,7 @@ class Pumpstation(Base):
     classification = Column(Integer)
     sewerage = Column(Boolean, nullable=False)
     type_ = Column(
-        IntegerEnum(constants.PumpType),
-        name="type",
-        key="type_",
-        nullable=False
+        IntegerEnum(constants.PumpType), name="type", key="type_", nullable=False
     )  # type: ignore[call-overload] # noqa
     start_level = Column(Float, nullable=False)
     lower_stop_level = Column(Float, nullable=False)
@@ -740,8 +765,10 @@ class Obstacle(Base):
     code = Column(String(100), nullable=False)
     crest_level = Column(Float, nullable=False)
     the_geom = Column(
-        Geometry(geometry_type="LINESTRING", srid=4326, spatial_index=True, management=True),
-        nullable=False
+        Geometry(
+            geometry_type="LINESTRING", srid=4326, spatial_index=True, management=True
+        ),
+        nullable=False,
     )
 
 
@@ -751,8 +778,10 @@ class Levee(Base):
     code = Column(String(100), default="", nullable=False)
     crest_level = Column(Float)
     the_geom = Column(
-        Geometry(geometry_type="LINESTRING", srid=4326, spatial_index=True, management=True),
-        nullable=False
+        Geometry(
+            geometry_type="LINESTRING", srid=4326, spatial_index=True, management=True
+        ),
+        nullable=False,
     )
     material = Column(IntegerEnum(constants.Material))
     max_breach_depth = Column(Float)
@@ -769,7 +798,8 @@ class ConnectedPoint(Base):
 
     exchange_level = Column(Float)
     the_geom = Column(
-        Geometry(geometry_type="POINT", srid=4326, spatial_index=True, management=True), nullable=False
+        Geometry(geometry_type="POINT", srid=4326, spatial_index=True, management=True),
+        nullable=False,
     )
 
 
@@ -788,8 +818,10 @@ class ImperviousSurface(Base):
     area = Column(Float)
     dry_weather_flow = Column(Float)
     the_geom = Column(
-        Geometry(geometry_type="POLYGON", srid=4326, spatial_index=True, management=True),
-        nullable=False
+        Geometry(
+            geometry_type="POLYGON", srid=4326, spatial_index=True, management=True
+        ),
+        nullable=False,
     )
     impervious_surface_maps = relationship(
         "ImperviousSurfaceMap", back_populates="impervious_surface"

--- a/threedi_modelchecker/threedi_model/models.py
+++ b/threedi_modelchecker/threedi_model/models.py
@@ -24,7 +24,7 @@ class Lateral2D(Base):
 
     type = Column(IntegerEnum(constants.Later2dType), nullable=False)
     the_geom = Column(
-        Geometry(geometry_type="POINT", srid=4326, spatial_index=True),
+        Geometry(geometry_type="POINT", srid=4326, spatial_index=True, management=True),
         nullable=False
     )
     timeseries = Column(Text, nullable=False)
@@ -38,7 +38,7 @@ class BoundaryConditions2D(Base):
     timeseries = Column(Text, nullable=False)
     boundary_type = Column(IntegerEnum(constants.BoundaryType), nullable=False)
     the_geom = Column(
-        Geometry(geometry_type="LINESTRING", srid=4326, spatial_index=True),
+        Geometry(geometry_type="LINESTRING", srid=4326, spatial_index=True, management=True),
         nullable=False
     )
 
@@ -51,7 +51,7 @@ class CalculationPoint(Base):
     user_ref = Column(String(80), nullable=False)
     calc_type = Column(Integer, nullable=False)
     the_geom = Column(
-        Geometry(geometry_type="POINT", srid=4326, spatial_index=True), nullable=False
+        Geometry(geometry_type="POINT", srid=4326, spatial_index=True, management=True), nullable=False
     )
 
 
@@ -157,7 +157,7 @@ class Floodfill(Base):
     __tablename__ = "v2_floodfill"
     id = Column(Integer, primary_key=True)
     waterlevel = Column(Float)
-    the_geom = Column(Geometry(geometry_type="POINT", srid=4326, spatial_index=True))
+    the_geom = Column(Geometry(geometry_type="POINT", srid=4326, spatial_index=True, management=True))
 
 
 class Interflow(Base):
@@ -179,7 +179,7 @@ class PumpedDrainageArea(Base):
     name = Column(String(64), nullable=False)
     code = Column(String(100), nullable=False)
     the_geom = Column(
-        Geometry(geometry_type="POLYGON", srid=4326, spatial_index=True), nullable=False
+        Geometry(geometry_type="POLYGON", srid=4326, spatial_index=True, management=True), nullable=False
     )
 
 
@@ -221,7 +221,7 @@ class Surface(Base):
         Integer, ForeignKey(SurfaceParameter.__tablename__ + ".id"), nullable=False
     )
     the_geom = Column(
-        Geometry(geometry_type="POLYGON", srid=4326, spatial_index=True),
+        Geometry(geometry_type="POLYGON", srid=4326, spatial_index=True, management=True),
         nullable=False
     )
 
@@ -266,7 +266,7 @@ class GridRefinement(Base):
     display_name = Column(String(255), nullable=False)
     refinement_level = Column(Integer, nullable=False)
     the_geom = Column(
-        Geometry(geometry_type="LINESTRING", srid=4326, spatial_index=True),
+        Geometry(geometry_type="LINESTRING", srid=4326, spatial_index=True, management=True),
         nullable=False
     )
     code = Column(String(100), nullable=False)
@@ -278,7 +278,7 @@ class GridRefinementArea(Base):
     display_name = Column(String(255), nullable=False)
     refinement_level = Column(Integer, nullable=False)
     code = Column(String(100), nullable=False)
-    the_geom = Column(Geometry(geometry_type="POLYGON", srid=4326, spatial_index=True))
+    the_geom = Column(Geometry(geometry_type="POLYGON", srid=4326, spatial_index=True, management=True))
 
 
 class CrossSectionDefinition(Base):
@@ -296,11 +296,11 @@ class ConnectionNode(Base):
     storage_area = Column(Float)
     initial_waterlevel = Column(Float)
     the_geom = Column(
-        Geometry(geometry_type="POINT", srid=4326, spatial_index=True),
+        Geometry(geometry_type="POINT", srid=4326, spatial_index=True, management=True),
         nullable=False
     )
     the_geom_linestring = Column(
-        Geometry(geometry_type="LINESTRING", srid=4326, spatial_index=False)
+        Geometry(geometry_type="LINESTRING", srid=4326, spatial_index=False, management=True)
     )
     code = Column(String(100), nullable=False)
 
@@ -487,7 +487,7 @@ class Channel(Base):
     dist_calc_points = Column(Float)
     zoom_category = Column(IntegerEnum(constants.ZoomCategories))
     the_geom = Column(
-        Geometry(geometry_type="LINESTRING", srid=4326, spatial_index=True),
+        Geometry(geometry_type="LINESTRING", srid=4326, spatial_index=True, management=True),
         nullable=False,
     )
 
@@ -519,7 +519,7 @@ class Windshielding(Base):
     southwest = Column(Float)
     west = Column(Float)
     northwest = Column(Float)
-    the_geom = Column(Geometry(geometry_type="POINT", srid=4326, spatial_index=True))
+    the_geom = Column(Geometry(geometry_type="POINT", srid=4326, spatial_index=True, management=True))
     channel_id = Column(
         Integer, ForeignKey(Channel.__tablename__ + ".id"), nullable=False
     )
@@ -534,7 +534,7 @@ class CrossSectionLocation(Base):
     friction_value = Column(Float, nullable=False)
     bank_level = Column(Float)
     the_geom = Column(
-        Geometry(geometry_type="POINT", srid=4326, spatial_index=True),
+        Geometry(geometry_type="POINT", srid=4326, spatial_index=True, management=True),
         nullable=False
     )
     channel_id = Column(
@@ -603,7 +603,7 @@ class Culvert(Base):
     invert_level_start_point = Column(Float, nullable=False)
     invert_level_end_point = Column(Float, nullable=False)
     the_geom = Column(
-        Geometry(geometry_type="LINESTRING", srid=4326, spatial_index=True),
+        Geometry(geometry_type="LINESTRING", srid=4326, spatial_index=True, management=True),
         nullable=False,
     )
 
@@ -630,7 +630,7 @@ class Culvert(Base):
 class DemAverageArea(Base):
     __tablename__ = "v2_dem_average_area"
     id = Column(Integer, primary_key=True)
-    the_geom = Column(Geometry(geometry_type="POLYGON", srid=4326, spatial_index=True))
+    the_geom = Column(Geometry(geometry_type="POLYGON", srid=4326, spatial_index=True, management=True))
 
 
 class Weir(Base):
@@ -740,7 +740,7 @@ class Obstacle(Base):
     code = Column(String(100), nullable=False)
     crest_level = Column(Float, nullable=False)
     the_geom = Column(
-        Geometry(geometry_type="LINESTRING", srid=4326, spatial_index=True),
+        Geometry(geometry_type="LINESTRING", srid=4326, spatial_index=True, management=True),
         nullable=False
     )
 
@@ -751,7 +751,7 @@ class Levee(Base):
     code = Column(String(100), default="", nullable=False)
     crest_level = Column(Float)
     the_geom = Column(
-        Geometry(geometry_type="LINESTRING", srid=4326, spatial_index=True),
+        Geometry(geometry_type="LINESTRING", srid=4326, spatial_index=True, management=True),
         nullable=False
     )
     material = Column(IntegerEnum(constants.Material))
@@ -769,7 +769,7 @@ class ConnectedPoint(Base):
 
     exchange_level = Column(Float)
     the_geom = Column(
-        Geometry(geometry_type="POINT", srid=4326, spatial_index=True), nullable=False
+        Geometry(geometry_type="POINT", srid=4326, spatial_index=True, management=True), nullable=False
     )
 
 
@@ -788,7 +788,7 @@ class ImperviousSurface(Base):
     area = Column(Float)
     dry_weather_flow = Column(Float)
     the_geom = Column(
-        Geometry(geometry_type="POLYGON", srid=4326, spatial_index=True),
+        Geometry(geometry_type="POLYGON", srid=4326, spatial_index=True, management=True),
         nullable=False
     )
     impervious_surface_maps = relationship(


### PR DESCRIPTION
I encountered this issue when I was writing tests for `threedigrid-builder`: geometry columns require `management=True` if the backend is sqlite. Otherwise you cannot create/destroy geometry columns.

See:
https://geoalchemy-2.readthedocs.io/en/latest/spatialite_tutorial.html#declare-a-mapping

I don't think that PostGIS is broken by this, because PostGIS also supports the AddGeometryColumn/DiscardGeometryColumn commands.