### PR TITLE
[Done] Add a checker for file existence

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of threedi-modelchecker
 0.14 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Added FileExistsCheck.
 
 
 0.13 (2021-06-17)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ install_requires = [
     "GeoAlchemy2>=0.6",
     "SQLAlchemy>=1.2",
     "alembic>=0.9",
-    "dataclasses ; python_version<'3.7'",
 ]
 
 tests_require = [

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ install_requires = [
     "GeoAlchemy2>=0.6",
     "SQLAlchemy>=1.2",
     "alembic>=0.9",
+    "dataclasses ; python_version<'3.7'",
 ]
 
 tests_require = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ import pytest
 from threedi_modelchecker.threedi_database import ThreediDatabase
 from threedi_modelchecker.model_checks import ThreediModelChecker, Context
 from tests import Session
-from pathlib import Path
 
 try:
     import psycopg2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,9 @@ import os
 import pytest
 
 from threedi_modelchecker.threedi_database import ThreediDatabase
-from threedi_modelchecker.model_checks import ThreediModelChecker
+from threedi_modelchecker.model_checks import ThreediModelChecker, Context
 from tests import Session
+from pathlib import Path
 
 try:
     import psycopg2
@@ -69,6 +70,7 @@ def session(threedi_db):
     :return: sqlalchemy.orm.session.Session
     """
     s = Session()
+    s.model_checker_context = Context()
     yield s
     # Rollback the session => no changes to the database
     s.rollback()

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,10 +1,10 @@
-import datetime
-
-import factory
 from factory import Faker
-
-from threedi_modelchecker.threedi_model import models, constants
 from tests import Session
+from threedi_modelchecker.threedi_model import constants
+from threedi_modelchecker.threedi_model import models
+
+import datetime
+import factory
 
 
 class GlobalSettingsFactory(factory.alchemy.SQLAlchemyModelFactory):
@@ -34,7 +34,13 @@ class GlobalSettingsFactory(factory.alchemy.SQLAlchemyModelFactory):
     use_0d_inflow = 0
     control_group_id = 1
 
-    dem_file = ""
+
+class SimpleInfiltrationFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = models.SimpleInfiltration
+        sqlalchemy_session = Session
+
+    infiltration_rate = 0.0
 
 
 class ControlGroupFactory(factory.alchemy.SQLAlchemyModelFactory):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -34,6 +34,8 @@ class GlobalSettingsFactory(factory.alchemy.SQLAlchemyModelFactory):
     use_0d_inflow = 0
     control_group_id = 1
 
+    dem_file = ""
+
 
 class ControlGroupFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:

--- a/tests/test_checks_base.py
+++ b/tests/test_checks_base.py
@@ -835,6 +835,14 @@ def test_file_exists_check_available_raster(session):
     assert len(invalid_rows) == 0
 
 
+def test_file_exists_check_not_available_raster(session):
+    factories.GlobalSettingsFactory(dem_file="some/file")
+    session.model_checker_context.available_rasters = {"frict_coef_file"}
+    check = FileExistsCheck(column=models.GlobalSetting.dem_file)
+    invalid_rows = check.get_invalid(session)
+    assert len(invalid_rows) == 1
+
+
 def test_file_exists_check_no_context(session):
     # no context, no check, no invalid records
     factories.GlobalSettingsFactory(dem_file="some/file")

--- a/tests/test_checks_base.py
+++ b/tests/test_checks_base.py
@@ -810,6 +810,7 @@ def test_length_geom_linestring_missing_epsg_from_global_settings(session):
     errors = check_length_linestring.get_invalid(session)
     assert len(errors) == 0
 
+
 def test_file_exists_check_filesystem_err(session, tmp_path):
     factories.GlobalSettingsFactory(dem_file="some/file")
     session.model_checker_context.base_path = tmp_path
@@ -825,7 +826,7 @@ def test_file_exists_check_filesystem_ok(session, tmp_path):
     check = FileExistsCheck(column=models.GlobalSetting.dem_file)
     invalid_rows = check.get_invalid(session)
     assert len(invalid_rows) == 0
-    
+
 
 def test_file_exists_check_available_raster(session):
     factories.GlobalSettingsFactory(dem_file="some/file")

--- a/tests/test_model_checks.py
+++ b/tests/test_model_checks.py
@@ -6,7 +6,6 @@ from .conftest import emtpy_sqlite_path
 
 from pathlib import Path
 from unittest import mock
-import pytest
 
 
 @pytest.fixture

--- a/tests/test_model_checks.py
+++ b/tests/test_model_checks.py
@@ -2,14 +2,23 @@ import pytest
 
 from threedi_modelchecker.model_checks import ThreediModelChecker
 from threedi_modelchecker.exporters import format_check_results
+from .conftest import emtpy_sqlite_path
 
+from pathlib import Path
 from unittest import mock
+import pytest
 
 
 @pytest.fixture
 def model_checker(threedi_db):
     with mock.patch("threedi_modelchecker.model_checks.ModelSchema"):
         return ThreediModelChecker(threedi_db)
+
+
+def test_set_base_path(model_checker):
+    if model_checker.db.db_type == "postgis":
+        pytest.skip("postgis does not have a base_path in the context")
+    assert model_checker.context.base_path == Path(emtpy_sqlite_path).parent
 
 
 def test_get_model_error_iterator(model_checker):

--- a/tests/test_model_checks.py
+++ b/tests/test_model_checks.py
@@ -16,8 +16,8 @@ def model_checker(threedi_db):
 
 
 def test_set_base_path(model_checker):
-    if model_checker.db.db_type == "postgis":
-        pytest.skip("postgis does not have a base_path in the context")
+    if model_checker.db.db_type == "postgres":
+        pytest.skip("postgres does not have a base_path in its context")
     assert model_checker.context.base_path == Path(emtpy_sqlite_path).parent
 
 

--- a/threedi_modelchecker/checks/base.py
+++ b/threedi_modelchecker/checks/base.py
@@ -316,6 +316,13 @@ class FileExistsCheck(BaseCheck):
 
     If the column contains an empty string, this check is skipped.
     """
+    def __init__(self, column, filters=()):
+        self._filters = filters
+        super().__init__(column)
+
+    def to_check(self, session):
+        _filters = (self.column != None, self.column != "") + tuple(self._filters)
+        return super().to_check(session).filter(*_filters)
 
     def none(self, session):
         return self.to_check(session).filter(false()).all()  # empty query
@@ -323,7 +330,7 @@ class FileExistsCheck(BaseCheck):
     def get_invalid(self, session):
         context = getattr(session, "model_checker_context", None)
         available_rasters = getattr(context, "available_rasters", None)
-        if available_rasters:
+        if available_rasters and self.to_check(session).count() > 0:
             if self.column.name in available_rasters:
                 # the raster is available (so says the context)
                 return self.none(session)

--- a/threedi_modelchecker/checks/base.py
+++ b/threedi_modelchecker/checks/base.py
@@ -317,19 +317,19 @@ class FileExistsCheck(BaseCheck):
     If the column contains an empty string, this check is skipped.
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.reason = None
-
     def none(self, session):
         return self.to_check(session).filter(false()).all()  # empty query
 
     def get_invalid(self, session):
         context = getattr(session, "model_checker_context", None)
         available_rasters = getattr(context, "available_rasters", None)
-        if available_rasters and self.column.name in available_rasters:
-            # the raster is available (so says the context)
-            return self.none(session)
+        if available_rasters:
+            if self.column.name in available_rasters:
+                # the raster is available (so says the context)
+                return self.none(session)
+            else:
+                # the raster is not available (so says the context)
+                return self.to_check(session).all()
 
         base_path = getattr(context, "base_path", None)
         if not base_path:

--- a/threedi_modelchecker/checks/base.py
+++ b/threedi_modelchecker/checks/base.py
@@ -314,10 +314,10 @@ class EnumCheck(BaseCheck):
 class FileExistsCheck(BaseCheck):
     """Check whether a file referenced in given Column exists.
 
-    In order to perform this check, the SQLAlchemy session requires a 
-    `model_checker_context` attribute, which is set automatically by the 
+    In order to perform this check, the SQLAlchemy session requires a
+    `model_checker_context` attribute, which is set automatically by the
     ThreediModelChecker and contains either `available_rasters` or `base_path`.
-    
+
     If it contains `available_rasters`, non-empty file fields are checked
     against this list. If a field contains a filename and does not occur in
     the list, the field is invalid.

--- a/threedi_modelchecker/checks/base.py
+++ b/threedi_modelchecker/checks/base.py
@@ -314,7 +314,19 @@ class EnumCheck(BaseCheck):
 class FileExistsCheck(BaseCheck):
     """Check whether a file referenced in given Column exists.
 
-    If the column contains an empty string, this check is skipped.
+    In order to perform this check, the SQLAlchemy session requires a 
+    `model_checker_context` attribute, which is set automatically by the 
+    ThreediModelChecker and contains either `available_rasters` or `base_path`.
+    
+    If it contains `available_rasters`, non-empty file fields are checked
+    against this list. If a field contains a filename and does not occur in
+    the list, the field is invalid.
+
+    Else, if it contains `base_path`, the file fields are checked in the local
+    filesystem. Paths are interpreted relative to `base_path`. The `base_path`
+    is set automatically by ThreediModelChecker if a spatialite is used.
+
+    If the context does not exist, the checker is skipped.
     """
     def __init__(self, column, filters=()):
         self._filters = filters

--- a/threedi_modelchecker/checks/base.py
+++ b/threedi_modelchecker/checks/base.py
@@ -346,4 +346,4 @@ class FileExistsCheck(BaseCheck):
         return self.to_check(session).filter(self.column.in_(invalid)).all()
 
     def description(self):
-        return f"file(s) specified in {self.column.name} are not present"
+        return f"file in {self.column} is not present"

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -628,16 +628,46 @@ FILE_EXISTS_CHECKS = [
     FileExistsCheck(column=models.GlobalSetting.dem_file),
     FileExistsCheck(column=models.GlobalSetting.frict_coef_file),
     FileExistsCheck(column=models.GlobalSetting.interception_file),
-    FileExistsCheck(column=models.Interflow.porosity_file),
-    FileExistsCheck(column=models.Interflow.hydraulic_conductivity_file),
-    FileExistsCheck(column=models.SimpleInfiltration.infiltration_rate_file),
-    FileExistsCheck(column=models.SimpleInfiltration.max_infiltration_capacity_file),
-    FileExistsCheck(column=models.GroundWater.groundwater_hydro_connectivity_file),
-    FileExistsCheck(column=models.GroundWater.phreatic_storage_capacity_file),
-    FileExistsCheck(column=models.GroundWater.equilibrium_infiltration_rate_file),
-    FileExistsCheck(column=models.GroundWater.initial_infiltration_rate_file),
-    FileExistsCheck(column=models.GroundWater.infiltration_decay_period_file),
-    FileExistsCheck(column=models.GroundWater.groundwater_hydro_connectivity_file),
+    FileExistsCheck(
+        column=models.Interflow.porosity_file,
+        filters=[models.Interflow.global_settings != None],
+    ),
+    FileExistsCheck(
+        column=models.Interflow.hydraulic_conductivity_file,
+        filters=[models.Interflow.global_settings != None],
+    ),
+    FileExistsCheck(
+        column=models.SimpleInfiltration.infiltration_rate_file,
+        filters=[models.SimpleInfiltration.global_settings != None],
+    ),
+    FileExistsCheck(
+        column=models.SimpleInfiltration.max_infiltration_capacity_file,
+        filters=[models.SimpleInfiltration.global_settings != None],
+    ),
+    FileExistsCheck(
+        column=models.GroundWater.groundwater_hydro_connectivity_file,
+        filters=[models.GroundWater.global_settings != None],
+    ),
+    FileExistsCheck(
+        column=models.GroundWater.phreatic_storage_capacity_file,
+        filters=[models.GroundWater.global_settings != None],
+    ),
+    FileExistsCheck(
+        column=models.GroundWater.equilibrium_infiltration_rate_file,
+        filters=[models.GroundWater.global_settings != None],
+    ),
+    FileExistsCheck(
+        column=models.GroundWater.initial_infiltration_rate_file,
+        filters=[models.GroundWater.global_settings != None],
+    ),
+    FileExistsCheck(
+        column=models.GroundWater.infiltration_decay_period_file,
+        filters=[models.GroundWater.global_settings != None],
+    ),
+    FileExistsCheck(
+        column=models.GroundWater.groundwater_hydro_connectivity_file,
+        filters=[models.GroundWater.global_settings != None],
+    ),
 ]
 
 

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -1,5 +1,6 @@
 from .checks.base import BaseCheck
 from .checks.base import EnumCheck
+from .checks.base import FileExistsCheck
 from .checks.base import ForeignKeyCheck
 from .checks.base import GeneralCheck
 from .checks.base import GeometryCheck
@@ -623,6 +624,23 @@ CONDITIONAL_CHECKS = [
 ]
 
 
+FILE_EXISTS_CHECKS = [
+    FileExistsCheck(column=models.GlobalSetting.dem_file),
+    FileExistsCheck(column=models.GlobalSetting.frict_coef_file),
+    FileExistsCheck(column=models.GlobalSetting.interception_file),
+    FileExistsCheck(column=models.Interflow.porosity_file),
+    FileExistsCheck(column=models.Interflow.hydraulic_conductivity_file),
+    FileExistsCheck(column=models.SimpleInfiltration.infiltration_rate_file),
+    FileExistsCheck(column=models.SimpleInfiltration.max_infiltration_capacity_file),
+    FileExistsCheck(column=models.GroundWater.groundwater_hydro_connectivity_file),
+    FileExistsCheck(column=models.GroundWater.phreatic_storage_capacity_file),
+    FileExistsCheck(column=models.GroundWater.equilibrium_infiltration_rate_file),
+    FileExistsCheck(column=models.GroundWater.initial_infiltration_rate_file),
+    FileExistsCheck(column=models.GroundWater.infiltration_decay_period_file),
+    FileExistsCheck(column=models.GroundWater.groundwater_hydro_connectivity_file),
+]
+
+
 class Config:
     """Collection of checks
 
@@ -663,4 +681,5 @@ class Config:
         self.checks += TIMESERIES_CHECKS
         self.checks += RANGE_CHECKS
         self.checks += CONDITIONAL_CHECKS
+        self.checks += FILE_EXISTS_CHECKS
         return None

--- a/threedi_modelchecker/model_checks.py
+++ b/threedi_modelchecker/model_checks.py
@@ -2,7 +2,6 @@ from .checks.base import BaseCheck
 from .config import Config
 from .schema import ModelSchema
 from .threedi_database import ThreediDatabase
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator
 from typing import NamedTuple
@@ -14,10 +13,14 @@ from typing import Tuple
 __all__ = ["ThreediModelChecker"]
 
 
-@dataclass
 class Context:
-    available_rasters: Optional[Set] = None
-    base_path: Optional[Path] = None
+    def __init__(
+        self,
+        available_rasters: Optional[Set] = None,
+        base_path: Optional[Path] = None,
+    ):
+        self.available_rasters = available_rasters
+        self.base_path = base_path
 
 
 class ThreediModelChecker:

--- a/threedi_modelchecker/threedi_database.py
+++ b/threedi_modelchecker/threedi_database.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from pathlib import Path
 from sqlalchemy import create_engine
 from sqlalchemy.event import listen
 from sqlalchemy.orm import sessionmaker
@@ -59,6 +60,11 @@ class ThreediDatabase:
     def engine(self):
         return self.get_engine()
 
+    @property
+    def base_path(self):
+        if self.db_type == "spatialite":
+            return Path(self.settings["db_path"]).absolute().parent
+
     def get_engine(self, get_seperate_engine=False):
 
         if self._engine is None or get_seperate_engine:
@@ -99,8 +105,7 @@ class ThreediDatabase:
 
     @contextmanager
     def session_scope(self, **kwargs):
-        """Get a session to execute a single transaction in a "with as" block.
-        """
+        """Get a session to execute a single transaction in a "with as" block."""
         session = self.get_session(**kwargs)
         try:
             yield session

--- a/threedi_modelchecker/threedi_model/models.py
+++ b/threedi_modelchecker/threedi_model/models.py
@@ -175,6 +175,8 @@ class Interflow(Base):
     hydraulic_conductivity_file = Column(String(255))
     display_name = Column(String(255), nullable=False)
 
+    global_settings = relationship("GlobalSetting", back_populates="interflow_settings")
+
 
 class PumpedDrainageArea(Base):
     __tablename__ = "v2_pumped_drainage_area"
@@ -199,6 +201,10 @@ class SimpleInfiltration(Base):
     )
     max_infiltration_capacity_file = Column(Text)
     display_name = Column(String(255), nullable=False)
+
+    global_settings = relationship(
+        "GlobalSetting", back_populates="simple_infiltration_settings"
+    )
 
 
 class SurfaceParameter(Base):
@@ -265,6 +271,10 @@ class GroundWater(Base):
     display_name = Column(String(255), nullable=False)
     leakage = Column(Float)
     leakage_file = Column(String(255))
+
+    global_settings = relationship(
+        "GlobalSetting", back_populates="groundwater_settings"
+    )
 
 
 class GridRefinement(Base):
@@ -439,12 +449,27 @@ class GlobalSetting(Base):
         Integer, ForeignKey(NumericalSettings.__tablename__ + ".id"), nullable=False
     )
     interflow_settings_id = Column(Integer, ForeignKey(Interflow.__tablename__ + ".id"))
+    interflow_settings = relationship(
+        Interflow,
+        foreign_keys=interflow_settings_id,
+        back_populates="global_settings",
+    )
     control_group_id = Column(Integer, ForeignKey(ControlGroup.__tablename__ + ".id"))
     simple_infiltration_settings_id = Column(
         Integer, ForeignKey(SimpleInfiltration.__tablename__ + ".id")
     )
+    simple_infiltration_settings = relationship(
+        SimpleInfiltration,
+        foreign_keys=simple_infiltration_settings_id,
+        back_populates="global_settings",
+    )
     groundwater_settings_id = Column(
         Integer, ForeignKey(GroundWater.__tablename__ + ".id")
+    )
+    groundwater_settings = relationship(
+        GroundWater,
+        foreign_keys=groundwater_settings_id,
+        back_populates="global_settings",
     )
 
 


### PR DESCRIPTION
This adds a `FileExistsChecker` along with configurations for all file fields in the SQLite.

Implementing this was quite tricky, because a `Checker` has no clue of its context, so it can't interpret paths relative to the sqlite. An additional complexity is that in the threedi-api the paths have no meaning and we have to come up with a different method of saying whether a raster is there or not.

I solved this by adding a `Context` object to the `ModelChecker`. The context contains 1) a list of available rasters (for the API) and 2) a base path, which is the directory containing the sqlite. The context is stuck to the session and picked up by the checker.