### PR TITLE
Add log levels (INFO and WARNING) and error codes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,13 @@ Changelog of threedi-modelchecker
 0.15 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Added log levels (INFO, WARNING, ERROR). The level of the checker can be
+  adjusted through ThreediModelChecker().errors and .checks. The command-line
+  interface also supports the --level parameter.
+
+- Fixed formatting of the command-line interface output.
+
+- Removed the summarize (--sum, --no-sum) option from the command-line interface.
 
 
 0.14 (2021-07-29)

--- a/README.rst
+++ b/README.rst
@@ -43,8 +43,18 @@ checks and print an overview of all discovered errors::
     )
 
     model_checker = ThreediModelChecker(database)
-    for check, error in model_checker.errors():
+    for check, error in model_checker.errors(level="WARNING"):
         print(format_check_results(check, error))
+
+
+Command-line interface
+----------------------
+
+Use the modelchecker from the command line as follows::
+
+    threedi-modelchecker -l warning sqlite -s path/to/model.sqlite
+
+By default, WARNING and INFO checks are ignored.
 
 
 Development

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,6 @@ flake8
 pytest
 pytest-cov
 pytest-flake8
-
+mock
 mypy
 sqlalchemy-stubs

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ GeoAlchemy2==0.6.1
 SQLAlchemy==1.3.1
 Click==7.0
 psycopg2
+alembic

--- a/threedi_modelchecker/checks/base.py
+++ b/threedi_modelchecker/checks/base.py
@@ -324,10 +324,8 @@ class EnumCheck(BaseCheck):
         return invalid_values_q.all()
 
     def description(self):
-        allowed = ", ".join([x.name for x in self.column.type.enum_class])
-        if len(allowed) > 40:
-            allowed = allowed[:37] + "..."
-        return f"Value in {self.column} is invalid, expected one of [{allowed}]"
+        allowed = {x.value for x in self.column.type.enum_class}
+        return f"Value in {self.column} is not one of {allowed}"
 
 
 class FileExistsCheck(BaseCheck):

--- a/threedi_modelchecker/checks/base.py
+++ b/threedi_modelchecker/checks/base.py
@@ -37,10 +37,10 @@ class BaseCheck(ABC):
     This method will return a list of rows (as named_tuples) which are invalid.
     """
 
-    def __init__(self, column, level=CheckLevel.ERROR, error_code=None):
+    def __init__(self, column, level=CheckLevel.ERROR, error_code=0):
         self.column = column
         self.table = column.table
-        self.error_code = error_code or "NOCODE"
+        self.error_code = int(error_code)
         self.level = CheckLevel.get(level)
 
     @abstractmethod
@@ -324,8 +324,10 @@ class EnumCheck(BaseCheck):
         return invalid_values_q.all()
 
     def description(self):
-        allowed = [x.name for x in self.column.type.enum_class]
-        return f"Value in {self.column} is invalid, expected one of {allowed}"
+        allowed = ", ".join([x.name for x in self.column.type.enum_class])
+        if len(allowed) > 40:
+            allowed = allowed[:37] + "..."
+        return f"Value in {self.column} is invalid, expected one of [{allowed}]"
 
 
 class FileExistsCheck(BaseCheck):

--- a/threedi_modelchecker/checks/base.py
+++ b/threedi_modelchecker/checks/base.py
@@ -351,15 +351,7 @@ class FileExistsCheck(BaseCheck):
         super().__init__(column, *args, **kwargs)
 
     def to_check(self, session):
-        return (
-            super()
-            .to_check(session)
-            .filter(
-                self.column != None,
-                self.column != "",
-                *self._filters,
-            )
-        )
+        return super().to_check(session).filter(*self._filters)
 
     def none(self, session):
         return self.to_check(session).filter(false()).all()  # empty query
@@ -382,7 +374,7 @@ class FileExistsCheck(BaseCheck):
 
         invalid = []
         for (path,) in session.query(self.column).all():
-            if path is None:
+            if not path:
                 continue  # Hopefully another check will handle this situation
             if not Path(base_path / path).exists():
                 invalid.append(path)

--- a/threedi_modelchecker/checks/base.py
+++ b/threedi_modelchecker/checks/base.py
@@ -165,9 +165,9 @@ class ForeignKeyCheck(BaseCheck):
         return invalid_foreign_keys_query.all()
 
     def description(self):
-        return "Missing foreign key in column %s, expected reference to %s." % (
+        return "%s refers to a non-existing %s" % (
             self.column,
-            self.reference_column,
+            self.reference_column.table,
         )
 
 
@@ -187,7 +187,7 @@ class UniqueCheck(BaseCheck):
         return invalid_uniques_query.all()
 
     def description(self):
-        return "Value in %s should to be unique" % self.column
+        return "%s should to be unique" % self.column
 
 
 class NotNullCheck(BaseCheck):
@@ -199,7 +199,7 @@ class NotNullCheck(BaseCheck):
         return not_null_query.all()
 
     def description(self):
-        return "Value in %s cannot be null" % self.column
+        return "%s cannot be null" % self.column
 
 
 class TypeCheck(BaseCheck):
@@ -222,7 +222,7 @@ class TypeCheck(BaseCheck):
         return invalid_type_query.all()
 
     def description(self):
-        return "Value in %s should to be of type %s" % (self.column, self.expected_type)
+        return "%s should to be of type %s" % (self.column, self.expected_type)
 
 
 def _sqlalchemy_to_sqlite_type(column_type):
@@ -271,7 +271,7 @@ class GeometryCheck(BaseCheck):
         return invalid_geometries.all()
 
     def description(self):
-        return "Value in %s is invalid geometry" % self.column
+        return "%s is an invalid geometry" % self.column
 
 
 class GeometryTypeCheck(BaseCheck):
@@ -292,7 +292,7 @@ class GeometryTypeCheck(BaseCheck):
         return invalid_geometry_types_q.all()
 
     def description(self):
-        return "Value in %s has invalid geometry type, expected geometry " "type %s" % (
+        return "%s has invalid geometry type, expected %s" % (
             self.column,
             self.column.type.geometry_type,
         )
@@ -325,7 +325,7 @@ class EnumCheck(BaseCheck):
 
     def description(self):
         allowed = {x.value for x in self.column.type.enum_class}
-        return f"Value in {self.column} is not one of {allowed}"
+        return f"{self.column} is not one of {allowed}"
 
 
 class FileExistsCheck(BaseCheck):

--- a/threedi_modelchecker/checks/factories.py
+++ b/threedi_modelchecker/checks/factories.py
@@ -13,7 +13,9 @@ def generate_foreign_key_checks(table, **kwargs):
     foreign_key_checks = []
     for fk_column in table.foreign_keys:
         foreign_key_checks.append(
-            ForeignKeyCheck(reference_column=fk_column.column, column=fk_column.parent, **kwargs)
+            ForeignKeyCheck(
+                reference_column=fk_column.column, column=fk_column.parent, **kwargs
+            )
         )
     return foreign_key_checks
 

--- a/threedi_modelchecker/checks/factories.py
+++ b/threedi_modelchecker/checks/factories.py
@@ -59,9 +59,17 @@ def generate_geometry_type_checks(table, **kwargs):
     return geometry_type_checks
 
 
+# Fields to log with less-than-ERROR level
+ENUM_LEVEL_MAP = {
+    "sewerage_type": "WARNING",
+    "zoom_category": "INFO",
+}
+
+
 def generate_enum_checks(table, **kwargs):
     enum_checks = []
     for column in table.columns:
         if issubclass(type(column.type), custom_types.CustomEnum):
-            enum_checks.append(EnumCheck(column, **kwargs))
+            level = ENUM_LEVEL_MAP.get(column.name, "ERROR")
+            enum_checks.append(EnumCheck(column, level=level, **kwargs))
     return enum_checks

--- a/threedi_modelchecker/checks/factories.py
+++ b/threedi_modelchecker/checks/factories.py
@@ -9,57 +9,57 @@ from .base import UniqueCheck
 from geoalchemy2.types import Geometry
 
 
-def generate_foreign_key_checks(table):
+def generate_foreign_key_checks(table, **kwargs):
     foreign_key_checks = []
     for fk_column in table.foreign_keys:
         foreign_key_checks.append(
-            ForeignKeyCheck(reference_column=fk_column.column, column=fk_column.parent)
+            ForeignKeyCheck(reference_column=fk_column.column, column=fk_column.parent, **kwargs)
         )
     return foreign_key_checks
 
 
-def generate_unique_checks(table):
+def generate_unique_checks(table, **kwargs):
     unique_checks = []
     for column in table.columns:
         if column.unique or column.primary_key:
-            unique_checks.append(UniqueCheck(column))
+            unique_checks.append(UniqueCheck(column, **kwargs))
     return unique_checks
 
 
-def generate_not_null_checks(table):
+def generate_not_null_checks(table, **kwargs):
     not_null_checks = []
     for column in table.columns:
         if not column.nullable:
-            not_null_checks.append(NotNullCheck(column))
+            not_null_checks.append(NotNullCheck(column, **kwargs))
     return not_null_checks
 
 
-def generate_type_checks(table):
+def generate_type_checks(table, **kwargs):
     data_type_checks = []
     for column in table.columns:
-        data_type_checks.append(TypeCheck(column))
+        data_type_checks.append(TypeCheck(column, **kwargs))
     return data_type_checks
 
 
-def generate_geometry_checks(table):
+def generate_geometry_checks(table, **kwargs):
     geometry_checks = []
     for column in table.columns:
         if type(column.type) == Geometry:
-            geometry_checks.append(GeometryCheck(column))
+            geometry_checks.append(GeometryCheck(column, **kwargs))
     return geometry_checks
 
 
-def generate_geometry_type_checks(table):
+def generate_geometry_type_checks(table, **kwargs):
     geometry_type_checks = []
     for column in table.columns:
         if type(column.type) == Geometry:
-            geometry_type_checks.append(GeometryTypeCheck(column))
+            geometry_type_checks.append(GeometryTypeCheck(column, **kwargs))
     return geometry_type_checks
 
 
-def generate_enum_checks(table):
+def generate_enum_checks(table, **kwargs):
     enum_checks = []
     for column in table.columns:
         if issubclass(type(column.type), custom_types.CustomEnum):
-            enum_checks.append(EnumCheck(column))
+            enum_checks.append(EnumCheck(column, **kwargs))
     return enum_checks

--- a/threedi_modelchecker/checks/other.py
+++ b/threedi_modelchecker/checks/other.py
@@ -18,8 +18,8 @@ class BankLevelCheck(BaseCheck):
     calculation_type is CONNECTED or DOUBLE_CONNECTED.
     """
 
-    def __init__(self):
-        super().__init__(column=models.CrossSectionLocation.bank_level)
+    def __init__(self, *args, **kwargs):
+        super().__init__(column=models.CrossSectionLocation.bank_level, *args, **kwargs)
 
     def get_invalid(self, session):
         q = session.query(self.table).filter(
@@ -45,8 +45,8 @@ class BankLevelCheck(BaseCheck):
 class CrossSectionShapeCheck(BaseCheck):
     """Check if all CrossSectionDefinition.shape are valid"""
 
-    def __init__(self):
-        super().__init__(column=models.CrossSectionDefinition.shape)
+    def __init__(self, *args, **kwargs):
+        super().__init__(column=models.CrossSectionDefinition.shape, *args, **kwargs)
 
     def get_invalid(self, session):
         cross_section_definitions = session.query(self.table)
@@ -190,8 +190,8 @@ class Use0DFlowCheck(BaseCheck):
     2, there is at least one impervious surface or surfaces respectively.
     """
 
-    def __init__(self):
-        super().__init__(column=models.GlobalSetting.use_0d_inflow)
+    def __init__(self, *args, **kwargs):
+        super().__init__(column=models.GlobalSetting.use_0d_inflow, *args, **kwargs)
 
     def to_check(self, session):
         """Return a Query object on which this check is applied"""
@@ -233,8 +233,8 @@ class ConnectionNodes(BaseCheck):
     - Weir
     """
 
-    def __init__(self):
-        super().__init__(column=models.ConnectionNode.id)
+    def __init__(self, *args, **kwargs):
+        super().__init__(column=models.ConnectionNode.id, *args, **kwargs)
 
     def get_invalid(self, session):
         raise NotImplementedError
@@ -359,8 +359,8 @@ class OpenChannelsWithNestedNewton(BaseCheck):
     See https://github.com/nens/threeditoolbox/issues/522
     """
 
-    def __init__(self):
-        super().__init__(column=models.Channel.id)
+    def __init__(self, *args, **kwargs):
+        super().__init__(column=models.Channel.id, *args, **kwargs)
 
     def get_invalid(self, session: Session) -> List[NamedTuple]:
         invalid_channels = []

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -1,5 +1,5 @@
 from .checks.base import BaseCheck
-from .checks.base import EnumCheck
+from .checks.base import EnumCheck, CheckLevel
 from .checks.base import FileExistsCheck
 from .checks.base import ForeignKeyCheck
 from .checks.base import GeneralCheck
@@ -713,3 +713,10 @@ class Config:
         self.checks += CONDITIONAL_CHECKS
         self.checks += FILE_EXISTS_CHECKS
         return None
+
+    def iter_checks(self, level=CheckLevel.ERROR):
+        """Iterate over checks with at least 'level'"""
+        level = CheckLevel.get(level)  # normalize
+        for check in self.checks:
+            if check.level >= level:
+                yield check

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -1,5 +1,6 @@
 from .checks.base import BaseCheck
-from .checks.base import EnumCheck, CheckLevel
+from .checks.base import CheckLevel
+from .checks.base import EnumCheck
 from .checks.base import FileExistsCheck
 from .checks.base import ForeignKeyCheck
 from .checks.base import GeneralCheck

--- a/threedi_modelchecker/exporters.py
+++ b/threedi_modelchecker/exporters.py
@@ -27,10 +27,10 @@ def export_to_file(errors, file):
 
 
 def format_check_results(check: BaseCheck, invalid_row: NamedTuple):
-    OUTPUT_FORMAT = "{level} {check} (row {row_id:d}) {description!s}"
+    OUTPUT_FORMAT = "{level}{error_code:04d} (row {row_id:d}) {description!s}"
     return OUTPUT_FORMAT.format(
-        level=check.level.name,
-        check=check.error_code,
+        level=check.level.name[:1],
+        error_code=check.error_code,
         row_id=invalid_row.id,
         description=check.description(),
     )

--- a/threedi_modelchecker/exporters.py
+++ b/threedi_modelchecker/exporters.py
@@ -1,4 +1,5 @@
-from collections import Counter
+from threedi_modelchecker.checks.base import BaseCheck
+from typing import NamedTuple
 
 
 def print_errors(errors):
@@ -7,7 +8,7 @@ def print_errors(errors):
     :param errors: iterator of BaseModelError
     """
     for error in errors:
-        print(error)
+        print(format_check_results(*error))
 
 
 def export_to_file(errors, file):
@@ -22,46 +23,14 @@ def export_to_file(errors, file):
     """
     with open(file, "w") as f:
         for error in errors:
-            f.write(str(error) + "\n")
+            f.write(format_check_results(*error) + "\n")
 
 
-def summarize_type_errors(errors):
-    """Return an summary of the errors, aggregated on the type of errors
-
-    Count for each type of error is returned.
-
-    :param errors: iterator of BaseModelError
-    :return: dict
-    """
-
-    def _get_error_type(errors):
-        for error in errors:
-            yield type(error).__name__
-
-    summary = Counter(_get_error_type(errors))
-    return summary, sum(summary.values())
-
-
-def summarize_column_errors(errors):
-    """Return a summary of the errors, aggregated on columns
-
-    For each column the number of errors are returned. Columns with no errors
-    are not returned.
-    """
-
-    def _get_error_table_column(errors):
-        for error in errors:
-            yield "%s.%s" % (error.column.table.name, error.column.name)
-
-    summary = Counter(_get_error_table_column(errors))
-    return summary, sum(summary.values())
-
-
-def format_check_results(check, invalid_row):
-    OUTPUT_FORMAT = '{check!r} row: {row_id:d} value: "{row_value!s}" {description!s}'
+def format_check_results(check: BaseCheck, invalid_row: NamedTuple):
+    OUTPUT_FORMAT = "{level} {check} (row {row_id:d}) {description!s}"
     return OUTPUT_FORMAT.format(
-        check=check,
+        level=check.level.name,
+        check=check.error_code,
         row_id=invalid_row.id,
-        row_value=getattr(invalid_row, check.column.name),
         description=check.description(),
     )

--- a/threedi_modelchecker/model_checks.py
+++ b/threedi_modelchecker/model_checks.py
@@ -1,4 +1,4 @@
-from .checks.base import BaseCheck
+from .checks.base import BaseCheck, CheckLevel
 from .config import Config
 from .schema import ModelSchema
 from .threedi_database import ThreediDatabase
@@ -44,24 +44,26 @@ class ThreediModelChecker:
         """Returns a list of declared models"""
         return self.schema.declared_models
 
-    def errors(self) -> Iterator[Tuple[BaseCheck, NamedTuple]]:
+    def errors(self, level=CheckLevel.ERROR) -> Iterator[Tuple[BaseCheck, NamedTuple]]:
         """Iterates and applies checks, returning any failing rows.
+
+        By default, checks of WARNING and INFO level are ignored.
 
         :return: Tuple of the applied check and the failing row.
         """
         session = self.db.get_session()
         session.model_checker_context = self.context
-        for check in self.checks():
+        for check in self.checks(level=level):
             model_errors = check.get_invalid(session)
             for error_row in model_errors:
                 yield check, error_row
 
-    def checks(self) -> Iterator[BaseCheck]:
+    def checks(self, level=CheckLevel.ERROR) -> Iterator[BaseCheck]:
         """Iterates over all configured checks
 
         :return: implementations of BaseChecks
         """
-        for check in self.config.checks:
+        for check in self.config.iter_checks(level=level):
             yield check
 
     def check_table(self, table):

--- a/threedi_modelchecker/model_checks.py
+++ b/threedi_modelchecker/model_checks.py
@@ -1,4 +1,5 @@
-from .checks.base import BaseCheck, CheckLevel
+from .checks.base import BaseCheck
+from .checks.base import CheckLevel
 from .config import Config
 from .schema import ModelSchema
 from .threedi_database import ThreediDatabase

--- a/threedi_modelchecker/schema.py
+++ b/threedi_modelchecker/schema.py
@@ -46,8 +46,7 @@ class ModelSchema:
         self.declared_models = declared_models
 
     def _get_version_old(self):
-        """The version of the database using the old 'south' versioning.
-        """
+        """The version of the database using the old 'south' versioning."""
         south_migrationhistory = Table(
             "south_migrationhistory", MetaData(), Column("id", Integer)
         )

--- a/threedi_modelchecker/scripts.py
+++ b/threedi_modelchecker/scripts.py
@@ -1,5 +1,5 @@
-from threedi_modelchecker.checks.base import CheckLevel
 from threedi_modelchecker import exporters
+from threedi_modelchecker.checks.base import CheckLevel
 from threedi_modelchecker.model_checks import ThreediModelChecker
 from threedi_modelchecker.threedi_database import ThreediDatabase
 
@@ -9,13 +9,14 @@ import click
 @click.group()
 @click.option("-f", "--file", help="Write errors to file, instead of stdout")
 @click.option(
-    "-s", "--sum/--no-sum", default=False, help="Prints a summary instead of all errors"
-)
-@click.option(
-    "-l", "--level", type=click.Choice([x.name for x in CheckLevel], case_sensitive=False), default="ERROR", help="Minimum level for checks. 'ERROR' by, meaning that 'WARNING' and 'INFO' are ignored."
+    "-l",
+    "--level",
+    type=click.Choice([x.name for x in CheckLevel], case_sensitive=False),
+    default="ERROR",
+    help="Minimum level for checks. 'ERROR' by, meaning that 'WARNING' and 'INFO' are ignored.",
 )
 @click.pass_context
-def check_model(ctx, file, sum, level):
+def check_model(ctx, file, level):
     """Checks the threedi-model for errors / warnings / info messages"""
     level = level.upper()
     if level == "ERROR":
@@ -27,8 +28,6 @@ def check_model(ctx, file, sum, level):
     click.echo("Parsing threedi-model for any %s" % msg)
     if file:
         click.echo("Model errors will be written to %s" % file)
-    if sum:
-        click.echo("Printing a summary of the found errors")
 
 
 @check_model.command()
@@ -75,15 +74,9 @@ def process(threedi_db, context):
     model_errors = mc.errors(level=context.params.get("level"))
 
     file_output = context.params.get("file")
-    summary = context.params.get("sum")
-    if context.params.get("file"):
+    if file_output:
         exporters.export_to_file(model_errors, file_output)
-    if summary:
-        error_summary, total_errors = exporters.summarize_type_errors(model_errors)
-        click.echo("---SUMMARY---")
-        click.echo("Total number of errors: %s" % total_errors)
-        click.echo(error_summary)
-    if not summary and not file_output:
+    else:
         exporters.print_errors(model_errors)
 
     click.echo("Finished processing model")

--- a/threedi_modelchecker/scripts.py
+++ b/threedi_modelchecker/scripts.py
@@ -13,7 +13,7 @@ import click
     "--level",
     type=click.Choice([x.name for x in CheckLevel], case_sensitive=False),
     default="ERROR",
-    help="Minimum level for checks. 'ERROR' by, meaning that 'WARNING' and 'INFO' are ignored.",
+    help="Minimum check level.",
 )
 @click.pass_context
 def check_model(ctx, file, level):

--- a/threedi_modelchecker/scripts.py
+++ b/threedi_modelchecker/scripts.py
@@ -1,3 +1,4 @@
+from threedi_modelchecker.checks.base import CheckLevel
 from threedi_modelchecker import exporters
 from threedi_modelchecker.model_checks import ThreediModelChecker
 from threedi_modelchecker.threedi_database import ThreediDatabase
@@ -10,10 +11,20 @@ import click
 @click.option(
     "-s", "--sum/--no-sum", default=False, help="Prints a summary instead of all errors"
 )
+@click.option(
+    "-l", "--level", type=click.Choice([x.name for x in CheckLevel], case_sensitive=False), default="ERROR", help="Minimum level for checks. 'ERROR' by, meaning that 'WARNING' and 'INFO' are ignored."
+)
 @click.pass_context
-def check_model(ctx, file, sum):
-    """Checks the threedi-model for errors"""
-    click.echo("Parsing threedi-model for any errors")
+def check_model(ctx, file, sum, level):
+    """Checks the threedi-model for errors / warnings / info messages"""
+    level = level.upper()
+    if level == "ERROR":
+        msg = "errors"
+    elif level == "WARNING":
+        msg = "errors or warnings"
+    else:
+        msg = "errors, warnings or info messages"
+    click.echo("Parsing threedi-model for any %s" % msg)
     if file:
         click.echo("Model errors will be written to %s" % file)
     if sum:
@@ -61,7 +72,7 @@ def sqlite(context, sqlite):
 
 def process(threedi_db, context):
     mc = ThreediModelChecker(threedi_db)
-    model_errors = mc.errors()
+    model_errors = mc.errors(level=context.params.get("level"))
 
     file_output = context.params.get("file")
     summary = context.params.get("sum")


### PR DESCRIPTION
This adds the option to specify a loglevel (`level="warning"`) and error_code (`error_code=12`) for specific checks.

I used the new levels (just for testing) for the enum checks. Now, a wrong sewerage_type results in a WARNING and a wrong zoom_category in an INFO.

I also fixed the command-line client:
- removed the (non-working) "summarize" option
- there was a formatter in place, but it wasn't used. Instead the raw python tuples were dumped. I enabled it and tweaked the output. It now looks like this:

```
(...)
E0000 (row 36) Value in v2_pipe.friction_type is invalid, expected one of [CHEZY, MANNING]
E0000 (row 37) Value in v2_pipe.friction_type is invalid, expected one of [CHEZY, MANNING]
E0000 (row 38) Value in v2_pipe.friction_type is invalid, expected one of [CHEZY, MANNING]
E0000 (row 39) Value in v2_pipe.friction_type is invalid, expected one of [CHEZY, MANNING]
E0000 (row 40) Value in v2_pipe.friction_type is invalid, expected one of [CHEZY, MANNING]
E0000 (row 41) Value in v2_pipe.friction_type is invalid, expected one of [CHEZY, MANNING]
E0000 (row 42) Value in v2_pipe.friction_type is invalid, expected one of [CHEZY, MANNING]
E0000 (row 1) Invalid timeseries
E0000 (row 4) Invalid timeseries
E0000 (row 1) The file in GlobalSetting.dem_file is not present
E0000 (row 1) The file in GlobalSetting.interception_file is not present
```