### PR TITLE
Also accept version 173

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Changelog of threedi-modelchecker
 - Display the table name instead of the internal model name in the error
   description.
 
+- Accept schematisations with version 173 by re-implementing the last migration from
+  the old stack.
+
 
 0.17 (2021-11-03)
 -----------------

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -181,7 +181,7 @@ class NumericalSettingsFactory(factory.alchemy.SQLAlchemyModelFactory):
         sqlalchemy_session = Session
 
     max_degree = 1
-    use_of_cg = 0
+    use_of_cg = 20
     use_of_nested_newton = 0
 
 

--- a/tests/test_simulaton_templates.py
+++ b/tests/test_simulaton_templates.py
@@ -535,7 +535,7 @@ def test_simulation_settings(session):
                 "pump_implicit_ratio": 1.0,
                 "time_integration_method": 0,
                 "use_nested_newton": False,
-                "use_of_cg": 0,
+                "use_of_cg": 20,
                 "use_preconditioner_cg": 1,
             },
         ),

--- a/threedi_modelchecker/threedi_model/constants.py
+++ b/threedi_modelchecker/threedi_model/constants.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 
-LATEST_SOUTH_MIGRATION_ID = 174
+LATEST_SOUTH_MIGRATION_ID = 173
 #  Migration 174 deletes some fields, which were already not present in the
 #  models of the threedi-modelchecker. Therefore we can both accept migration
 #  173 and 174.


### PR DESCRIPTION
This implements https://github.com/nens/threedi/blob/master/lib/threedi-tools/threedi_tools/migrations/0172_auto__del_v2initialwaterlevel__del_field_v2orifice_max_capacity__del_f.py#L11  so that we can also accept version 173 (not sure about the off-by-one here)