### PR TITLE
Done: Some checks for control structures

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -208,11 +208,11 @@ class ControlTableFactory(factory.alchemy.SQLAlchemyModelFactory):
         model = models.ControlTable
         sqlalchemy_session = Session
 
-    action_type = "set_discharge_coefficients"
+    action_type = constants.ControlTableActionTypes.set_discharge_coefficients
     action_table = "0.0;-1.0"
-    measure_operator = ">"
-    measure_variable = "waterlevel"
-    target_type = "v2_channel"
+    measure_operator = constants.MeasureOperators.greater_than
+    measure_variable = constants.MeasureVariables.waterlevel
+    target_type = constants.StructureControlTypes.channel
     target_id = 10
 
 
@@ -221,10 +221,10 @@ class ControlMemoryFactory(factory.alchemy.SQLAlchemyModelFactory):
         model = models.ControlMemory
         sqlalchemy_session = Session
 
-    action_type = "set_discharge_coefficients"
+    action_type = constants.ControlTableActionTypes.set_discharge_coefficients
     action_value = "0.0 -1.0"
-    measure_variable = "waterlevel"
-    target_type = "v2_channel"
+    measure_variable = constants.MeasureVariables.waterlevel
+    target_type = constants.StructureControlTypes.channel
     target_id = 10
     is_inverse = False
     is_active = True

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -213,6 +213,7 @@ class ControlTableFactory(factory.alchemy.SQLAlchemyModelFactory):
     measure_operator = constants.MeasureOperators.greater_than
     measure_variable = constants.MeasureVariables.waterlevel
     target_type = constants.StructureControlTypes.channel
+    target_id = 10
 
 
 class ControlMemoryFactory(factory.alchemy.SQLAlchemyModelFactory):

--- a/tests/test_simulaton_templates.py
+++ b/tests/test_simulaton_templates.py
@@ -65,7 +65,7 @@ from threedi_modelchecker.simulation_templates.settings.extractor import (
 from threedi_modelchecker.simulation_templates.structure_controls.extractor import (
     StructureControlExtractor,
 )
-from threedi_modelchecker.threedi_model.constants import InitializationType
+from threedi_modelchecker.threedi_model.constants import InitializationType, ControlTableActionTypes
 from threedi_modelchecker.threedi_model.models import ControlGroup
 from threedi_modelchecker.threedi_model.models import ControlMeasureGroup
 from threedi_modelchecker.threedi_model.models import ControlMemory
@@ -698,7 +698,7 @@ def test_table_control_capacity_factor(session, measure_group):
         id=1, name="test group"
     )
     table_control: ControlTable = factories.ControlTableFactory.create(
-        id=1, action_table="0.0;100#1.0;200", action_type="set_capacity",
+        id=1, action_table="0.0;100#1.0;200", action_type=ControlTableActionTypes.set_capacity,
     )
 
     factories.ControlFactory.create(
@@ -718,7 +718,7 @@ def test_memory_control_capacity_factor(session, measure_group):
         id=1, name="test group"
     )
     memory_control: ControlMemory = factories.ControlMemoryFactory.create(
-        id=1, action_value="100", action_type="set_capacity",
+        id=1, action_value="100", action_type=ControlTableActionTypes.set_capacity,
     )
     factories.ControlFactory.create(
         control_group_id=control_group.id,

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -1,10 +1,11 @@
+from sqlalchemy.sql.schema import ForeignKey
 from .checks.base import BaseCheck
 from .checks.base import CheckLevel
 from .checks.base import FileExistsCheck
 from .checks.base import GeneralCheck
 from .checks.base import NotNullCheck
 from .checks.base import QueryCheck
-from .checks.base import RangeCheck
+from .checks.base import RangeCheck, ForeignKeyCheck
 from .checks.cross_section_definitions import CrossSectionEqualElementsCheck
 from .checks.cross_section_definitions import (
     CrossSectionFirstElementNonZeroCheck,
@@ -1346,6 +1347,65 @@ CHECKS += [
         models.Lateral1d.timeseries,
         models.Lateral2D.timeseries,
     ]
+]
+
+## 122x Structure controls
+
+CHECKS += [
+    ForeignKeyCheck(
+        error_code=1220,
+        column=models.ControlMeasureMap.object_id,
+        reference_column=models.ConnectionNode.id,
+        filter=models.ControlMeasureMap.object_type == constants.MeasureLocationContentTypes.connection_node.value
+    )
+]
+CHECKS += [
+    ForeignKeyCheck(
+        error_code=1221,
+        column=getattr(control_table, "target_id"),
+        reference_column=models.Channel.id,
+        filter=getattr(control_table, "target_type") == "v2_channel"
+    ) for control_table in (models.ControlMemory, models.ControlTable) 
+]
+CHECKS += [
+    ForeignKeyCheck(
+        error_code=1222,
+        column=getattr(control_table, "target_id"),
+        reference_column=models.Pipe.id,
+        filter=getattr(control_table, "target_type") == "v2_pipe"
+    ) for control_table in (models.ControlMemory, models.ControlTable) 
+]
+CHECKS += [
+    ForeignKeyCheck(
+        error_code=1223,
+        column=getattr(control_table, "target_id"),
+        reference_column=models.Orifice.id,
+        filter=getattr(control_table, "target_type") == "v2_orifice"
+    ) for control_table in (models.ControlMemory, models.ControlTable) 
+]
+CHECKS += [
+    ForeignKeyCheck(
+        error_code=1224,
+        column=getattr(control_table, "target_id"),
+        reference_column=models.Culvert.id,
+        filter=getattr(control_table, "target_type") == "v2_culvert"
+    ) for control_table in (models.ControlMemory, models.ControlTable) 
+]
+CHECKS += [
+    ForeignKeyCheck(
+        error_code=1225,
+        column=getattr(control_table, "target_id"),
+        reference_column=models.Weir.id,
+        filter=getattr(control_table, "target_type") == "v2_weir"
+    ) for control_table in (models.ControlMemory, models.ControlTable) 
+]
+CHECKS += [
+    ForeignKeyCheck(
+        error_code=1226,
+        column=getattr(control_table, "target_id"),
+        reference_column=models.Pumpstation.id,
+        filter=getattr(control_table, "target_type") == "v2_pumpstation"
+    ) for control_table in (models.ControlMemory, models.ControlTable) 
 ]
 
 

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -1,11 +1,11 @@
-from sqlalchemy.sql import true
 from .checks.base import BaseCheck
 from .checks.base import CheckLevel
 from .checks.base import FileExistsCheck
+from .checks.base import ForeignKeyCheck
 from .checks.base import GeneralCheck
 from .checks.base import NotNullCheck
 from .checks.base import QueryCheck
-from .checks.base import RangeCheck, ForeignKeyCheck
+from .checks.base import RangeCheck
 from .checks.cross_section_definitions import CrossSectionEqualElementsCheck
 from .checks.cross_section_definitions import (
     CrossSectionFirstElementNonZeroCheck,
@@ -1356,7 +1356,7 @@ CHECKS += [
         error_code=1220,
         column=models.ControlMeasureMap.object_id,
         reference_column=models.ConnectionNode.id,
-        filters=models.ControlMeasureMap.object_type == "v2_connection_node"
+        filters=models.ControlMeasureMap.object_type == "v2_connection_node",
     )
 ]
 CHECKS += [
@@ -1364,48 +1364,54 @@ CHECKS += [
         error_code=1221,
         column=control_table.target_id,
         reference_column=models.Channel.id,
-        filters=control_table.target_type == "v2_channel"
-    ) for control_table in (models.ControlMemory, models.ControlTable) 
+        filters=control_table.target_type == "v2_channel",
+    )
+    for control_table in (models.ControlMemory, models.ControlTable)
 ]
 CHECKS += [
     ForeignKeyCheck(
         error_code=1222,
         column=control_table.target_id,
         reference_column=models.Pipe.id,
-        filters=control_table.target_type == "v2_pipe"
-    ) for control_table in (models.ControlMemory, models.ControlTable) 
+        filters=control_table.target_type == "v2_pipe",
+    )
+    for control_table in (models.ControlMemory, models.ControlTable)
 ]
 CHECKS += [
     ForeignKeyCheck(
         error_code=1223,
         column=control_table.target_id,
         reference_column=models.Orifice.id,
-        filters=control_table.target_type == "v2_orifice"
-    ) for control_table in (models.ControlMemory, models.ControlTable) 
+        filters=control_table.target_type == "v2_orifice",
+    )
+    for control_table in (models.ControlMemory, models.ControlTable)
 ]
 CHECKS += [
     ForeignKeyCheck(
         error_code=1224,
         column=control_table.target_id,
         reference_column=models.Culvert.id,
-        filters=control_table.target_type == "v2_culvert"
-    ) for control_table in (models.ControlMemory, models.ControlTable) 
+        filters=control_table.target_type == "v2_culvert",
+    )
+    for control_table in (models.ControlMemory, models.ControlTable)
 ]
 CHECKS += [
     ForeignKeyCheck(
         error_code=1225,
         column=control_table.target_id,
         reference_column=models.Weir.id,
-        filters=control_table.target_type == "v2_weir"
-    ) for control_table in (models.ControlMemory, models.ControlTable) 
+        filters=control_table.target_type == "v2_weir",
+    )
+    for control_table in (models.ControlMemory, models.ControlTable)
 ]
 CHECKS += [
     ForeignKeyCheck(
         error_code=1226,
         column=control_table.target_id,
         reference_column=models.Pumpstation.id,
-        filters=control_table.target_type == "v2_pumpstation"
-    ) for control_table in (models.ControlMemory, models.ControlTable) 
+        filters=control_table.target_type == "v2_pumpstation",
+    )
+    for control_table in (models.ControlMemory, models.ControlTable)
 ]
 
 

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -1,4 +1,4 @@
-from sqlalchemy.sql.schema import ForeignKey
+from sqlalchemy.sql import true
 from .checks.base import BaseCheck
 from .checks.base import CheckLevel
 from .checks.base import FileExistsCheck
@@ -1356,55 +1356,55 @@ CHECKS += [
         error_code=1220,
         column=models.ControlMeasureMap.object_id,
         reference_column=models.ConnectionNode.id,
-        filter=models.ControlMeasureMap.object_type == constants.MeasureLocationContentTypes.connection_node.value
+        filters=models.ControlMeasureMap.object_type == "v2_connection_node"
     )
 ]
 CHECKS += [
     ForeignKeyCheck(
         error_code=1221,
-        column=getattr(control_table, "target_id"),
+        column=control_table.target_id,
         reference_column=models.Channel.id,
-        filter=getattr(control_table, "target_type") == "v2_channel"
+        filters=control_table.target_type == "v2_channel"
     ) for control_table in (models.ControlMemory, models.ControlTable) 
 ]
 CHECKS += [
     ForeignKeyCheck(
         error_code=1222,
-        column=getattr(control_table, "target_id"),
+        column=control_table.target_id,
         reference_column=models.Pipe.id,
-        filter=getattr(control_table, "target_type") == "v2_pipe"
+        filters=control_table.target_type == "v2_pipe"
     ) for control_table in (models.ControlMemory, models.ControlTable) 
 ]
 CHECKS += [
     ForeignKeyCheck(
         error_code=1223,
-        column=getattr(control_table, "target_id"),
+        column=control_table.target_id,
         reference_column=models.Orifice.id,
-        filter=getattr(control_table, "target_type") == "v2_orifice"
+        filters=control_table.target_type == "v2_orifice"
     ) for control_table in (models.ControlMemory, models.ControlTable) 
 ]
 CHECKS += [
     ForeignKeyCheck(
         error_code=1224,
-        column=getattr(control_table, "target_id"),
+        column=control_table.target_id,
         reference_column=models.Culvert.id,
-        filter=getattr(control_table, "target_type") == "v2_culvert"
+        filters=control_table.target_type == "v2_culvert"
     ) for control_table in (models.ControlMemory, models.ControlTable) 
 ]
 CHECKS += [
     ForeignKeyCheck(
         error_code=1225,
-        column=getattr(control_table, "target_id"),
+        column=control_table.target_id,
         reference_column=models.Weir.id,
-        filter=getattr(control_table, "target_type") == "v2_weir"
+        filters=control_table.target_type == "v2_weir"
     ) for control_table in (models.ControlMemory, models.ControlTable) 
 ]
 CHECKS += [
     ForeignKeyCheck(
         error_code=1226,
-        column=getattr(control_table, "target_id"),
+        column=control_table.target_id,
         reference_column=models.Pumpstation.id,
-        filter=getattr(control_table, "target_type") == "v2_pumpstation"
+        filters=control_table.target_type == "v2_pumpstation"
     ) for control_table in (models.ControlMemory, models.ControlTable) 
 ]
 

--- a/threedi_modelchecker/migrations/versions/0206_control_structures.py
+++ b/threedi_modelchecker/migrations/versions/0206_control_structures.py
@@ -1,0 +1,51 @@
+"""make settings nullable
+
+Revision ID: 0206
+Revises: 0205
+Create Date: 2021-12-16 13:30:00
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "0206"
+down_revision = "0205"
+branch_labels = None
+depends_on = None
+
+
+MIGRATION_QUERIES = """
+UPDATE v2_control_measure_map SET weight = 1.0 WHERE weight IS NULL;
+"""
+
+
+def upgrade():
+    for q in MIGRATION_QUERIES.split(";"):
+        op.execute(q)
+
+    with op.batch_alter_table("v2_control_measure_map") as batch_op:
+        batch_op.alter_column("object_id", nullable=False)
+        batch_op.alter_column("object_type", nullable=False)
+        batch_op.alter_column("weight", nullable=False)
+
+    with op.batch_alter_table("v2_control_memory") as batch_op:
+        batch_op.alter_column("measure_variable", nullable=False)
+        batch_op.alter_column("action_type", nullable=False)
+        batch_op.alter_column("action_value", nullable=False)
+        batch_op.alter_column("target_type", nullable=False)
+        batch_op.alter_column("target_id", nullable=False)
+
+    with op.batch_alter_table("v2_control_table") as batch_op:
+        batch_op.alter_column("measure_variable", nullable=False)
+        batch_op.alter_column("action_type", nullable=False)
+        batch_op.alter_column("action_table", nullable=False)
+        batch_op.alter_column("target_type", nullable=False)
+        batch_op.alter_column("target_id", nullable=False)
+
+    with op.batch_alter_table("v2_control") as batch_op:
+        batch_op.alter_column("control_type", nullable=False)
+
+
+def downgrade():
+    pass

--- a/threedi_modelchecker/simulation_templates/structure_controls/extractor.py
+++ b/threedi_modelchecker/simulation_templates/structure_controls/extractor.py
@@ -63,7 +63,7 @@ def to_measure_specification(
         operator = control.measure_operator
 
     return MeasureSpecification(
-        name=group.name[:50],
+        name=group.name[:50] if group.name else "",
         variable=VARIABLE_MAPPING[control.measure_variable],
         locations=locations,
         operator=operator,
@@ -156,8 +156,8 @@ def to_memory_control(
         structure_type=memory_control.target_type,
         type=action_type,
         value=value,
-        upper_threshold=float(memory_control.upper_threshold),
-        lower_threshold=float(memory_control.lower_threshold),
+        upper_threshold=memory_control.upper_threshold,
+        lower_threshold=memory_control.lower_threshold,
         is_inverse=bool(memory_control.is_inverse),
         is_active=bool(memory_control.is_active),
     )

--- a/threedi_modelchecker/simulation_templates/structure_controls/extractor.py
+++ b/threedi_modelchecker/simulation_templates/structure_controls/extractor.py
@@ -23,7 +23,7 @@ from threedi_modelchecker.threedi_model.constants import (
 )
 from threedi_modelchecker.threedi_model.constants import ControlType
 from threedi_modelchecker.threedi_model.constants import (
-    MeasureLocationContentTypes,
+    MeasureLocationContentTypes, MeasureVariables
 )
 from threedi_modelchecker.threedi_model.models import Control
 from threedi_modelchecker.threedi_model.models import ControlGroup
@@ -60,10 +60,10 @@ def to_measure_specification(
     locations: List[MeasureLocation],
 ) -> MeasureSpecification:
     VARIABLE_MAPPING = {
-        "waterlevel": "s1",
-        "volume": "vol1",
-        "discharge": "q",
-        "velocity": "u1",
+        MeasureVariables.waterlevel: "s1",
+        MeasureVariables.volume: "vol1",
+        MeasureVariables.discharge: "q",
+        MeasureVariables.velocity: "u1",
     }
 
     # Use > as default for memory control
@@ -73,7 +73,7 @@ def to_measure_specification(
 
     return MeasureSpecification(
         name=group.name[:50] if group.name else "",
-        variable=VARIABLE_MAPPING[control.measure_variable.value],
+        variable=VARIABLE_MAPPING[control.measure_variable],
         locations=locations,
         operator=operator,
     )

--- a/threedi_modelchecker/simulation_templates/structure_controls/extractor.py
+++ b/threedi_modelchecker/simulation_templates/structure_controls/extractor.py
@@ -18,7 +18,13 @@ from threedi_modelchecker.simulation_templates.models import StructureControls
 from threedi_modelchecker.simulation_templates.utils import (
     strip_dict_none_values,
 )
-from threedi_modelchecker.threedi_model.constants import ControlTableActionTypes, ControlType, MeasureLocationContentTypes
+from threedi_modelchecker.threedi_model.constants import (
+    ControlTableActionTypes,
+)
+from threedi_modelchecker.threedi_model.constants import ControlType
+from threedi_modelchecker.threedi_model.constants import (
+    MeasureLocationContentTypes,
+)
 from threedi_modelchecker.threedi_model.models import Control
 from threedi_modelchecker.threedi_model.models import ControlGroup
 from threedi_modelchecker.threedi_model.models import ControlMeasureGroup
@@ -37,10 +43,12 @@ def control_measure_map_to_measure_location(
     c_measure_map: ControlMeasureMap,
 ) -> MeasureLocation:
     # Connection nodes should be only option here.
-    CONTENT_TYPE_MAP = {MeasureLocationContentTypes.v2_connection_nodes: "v2_connection_node"}
+    CONTENT_TYPE_MAP = {
+        MeasureLocationContentTypes.v2_connection_nodes: "v2_connection_node"
+    }
 
     return MeasureLocation(
-        weight=f"{float(c_measure_map.weight):.2f}",
+        weight=str(round(float(c_measure_map.weight), 2)),
         content_type=CONTENT_TYPE_MAP[c_measure_map.object_type],
         content_pk=c_measure_map.object_id,
     )
@@ -241,7 +249,9 @@ class StructureControlExtractor(object):
                     measure_spec = to_measure_specification(memory, group, maps)
                     api_control = to_memory_control(control, memory, measure_spec)
                 else:
-                    raise SchematisationError(f"Unknown control_type '{control.control_type.value}'")
+                    raise SchematisationError(
+                        f"Unknown control_type '{control.control_type.value}'"
+                    )
                 self._controls[control.control_type.value].append(api_control)
 
     def all_controls(self) -> StructureControls:

--- a/threedi_modelchecker/threedi_model/constants.py
+++ b/threedi_modelchecker/threedi_model/constants.py
@@ -215,11 +215,12 @@ class StructureControlTypes(Enum):
 class ControlTableActionTypes(Enum):
     set_discharge_coefficients = "set_discharge_coefficients"  # not pump
     set_crest_level = "set_crest_level"  # orifice, weir only
-    set_pump_capacity = "set_capacity"  # only pump, in API: set_pump_capacity, 
+    set_pump_capacity = "set_pump_capacity"  # only pump, in API: set_pump_capacity
+    set_capacity = "set_capacity"  # old form, mapped to set_pump_capacity
 
 
 class MeasureLocationContentTypes(Enum):
-    connection_node = "v2_connection_node"
+    v2_connection_nodes = "v2_connection_nodes"  # in API: v2_connection_node (singular)
     # pipe = "v2_pipe"  # --> line cnode a-b
     # orifice = "v2_orifice"  # --> line cnode a-b
     # culvert = "v2_culvert"  # --> line cnode a-b

--- a/threedi_modelchecker/threedi_model/constants.py
+++ b/threedi_modelchecker/threedi_model/constants.py
@@ -196,3 +196,46 @@ class LimiterSlopeXArea(Enum):
 
 class IntegrationMethod(Enum):
     EULER_IMPLICIT = 0
+
+
+class ControlType(Enum):
+    memory = "memory"
+    table = "table"
+
+
+class StructureControlTypes(Enum):
+    pumpstation = "v2_pumpstation"
+    pipe = "v2_pipe"
+    orifice = "v2_orifice"
+    culvert = "v2_culvert"
+    weir = "v2_weir"
+    channel = "v2_channel"
+
+
+class ControlTableActionTypes(Enum):
+    set_discharge_coefficients = "set_discharge_coefficients"  # not pump
+    set_crest_level = "set_crest_level"  # orifice, weir only
+    set_pump_capacity = "set_capacity"  # only pump, in API: set_pump_capacity, 
+
+
+class MeasureLocationContentTypes(Enum):
+    connection_node = "v2_connection_node"
+    # pipe = "v2_pipe"  # --> line cnode a-b
+    # orifice = "v2_orifice"  # --> line cnode a-b
+    # culvert = "v2_culvert"  # --> line cnode a-b
+    # channel = "v2_channel"  # --> line cnode a-b
+    # weir = "v2_weir"  # --> line cnode a-b
+
+
+class MeasureVariables(Enum):
+    waterlevel = "waterlevel"  # in API: "s1"
+    volume = "volume"  # in API: "vol1"
+    discharge = "discharge"  # in API: "q"
+    velocity = "velocity"  # in API: "u1"
+
+
+class MeasureOperators(Enum):
+    greater_than = ">"
+    greater_than_equal = ">="
+    less_than = "<"
+    less_than_equal = "<="

--- a/threedi_modelchecker/threedi_model/models.py
+++ b/threedi_modelchecker/threedi_model/models.py
@@ -87,23 +87,23 @@ class ControlMeasureMap(Base):
     measure_group_id = Column(
         Integer, ForeignKey(ControlMeasureGroup.__tablename__ + ".id")
     )
-    object_type = Column(String(100))
-    object_id = Column(Integer)
-    weight = Column(Float)
+    object_type = Column(VarcharEnum(constants.MeasureLocationContentTypes), nullable=False)
+    object_id = Column(Integer, nullable=False)
+    weight = Column(Float, nullable=False)
 
 
 class ControlMemory(Base):
     __tablename__ = "v2_control_memory"
     id = Column(Integer, primary_key=True)
-    measure_variable = Column(String(50))
+    measure_variable = Column(VarcharEnum(constants.MeasureVariables), nullable=False)
     upper_threshold = Column(Float)
     lower_threshold = Column(Float)
-    action_type = Column(String(50))
-    action_value = Column(String(50))
-    target_type = Column(String(100))
-    target_id = Column(Integer)
-    is_active = Column(Boolean, nullable=False)
-    is_inverse = Column(Boolean, nullable=False)
+    action_type = Column(VarcharEnum(constants.ControlTableActionTypes), nullable=False)
+    action_value = Column(String(50), nullable=False)
+    target_type = Column(VarcharEnum(constants.StructureControlTypes), nullable=False)
+    target_id = Column(Integer, nullable=False)
+    is_active = Column(Boolean)
+    is_inverse = Column(Boolean)
 
 
 class ControlPID(Base):
@@ -123,12 +123,12 @@ class ControlPID(Base):
 class ControlTable(Base):
     __tablename__ = "v2_control_table"
     id = Column(Integer, primary_key=True)
-    action_table = Column(Text)
-    action_type = Column(String(50))
-    measure_variable = Column(String(50))
-    measure_operator = Column(String(2))
-    target_type = Column(String(100))
-    target_id = Column(Integer)
+    action_table = Column(Text, nullable=False)
+    action_type = Column(VarcharEnum(constants.ControlTableActionTypes), nullable=False)
+    measure_variable = Column(VarcharEnum(constants.MeasureVariables), nullable=False)
+    measure_operator = Column(VarcharEnum(constants.MeasureOperators))
+    target_type = Column(VarcharEnum(constants.StructureControlTypes), nullable=False)
+    target_id = Column(Integer, nullable=False)
 
 
 class ControlTimed(Base):
@@ -147,7 +147,7 @@ class Control(Base):
     measure_group_id = Column(
         Integer, ForeignKey(ControlMeasureGroup.__tablename__ + ".id")
     )
-    control_type = Column(String(15))
+    control_type = Column(VarcharEnum(constants.ControlType), nullable=False)
     control_id = Column(Integer)
     start = Column(String(50))
     end = Column(String(50))

--- a/threedi_modelchecker/threedi_model/models.py
+++ b/threedi_modelchecker/threedi_model/models.py
@@ -87,7 +87,9 @@ class ControlMeasureMap(Base):
     measure_group_id = Column(
         Integer, ForeignKey(ControlMeasureGroup.__tablename__ + ".id")
     )
-    object_type = Column(VarcharEnum(constants.MeasureLocationContentTypes), nullable=False)
+    object_type = Column(
+        VarcharEnum(constants.MeasureLocationContentTypes), nullable=False
+    )
     object_id = Column(Integer, nullable=False)
     weight = Column(Float, nullable=False)
 


### PR DESCRIPTION
This enforces a more strict datamodel for the controls. There are checks on nullability, enums, and foreign key references. Note that the nullability and enum checks are automatically generated just by changing the data model.

There is potentially a lot more validations to do:

- action_value and action_tables fields
- sum of weights must be 1
- certain combinations of action_type and structure_type

- [x] unittests pass
- [x] no errors with existing models in inpy-success (modelchecker)
- [x] no errors with existing models in inpy-success (template worker)

There were ~13 models with weight=NULL, I migrated these to weight=1.0 (because all these models had just 1 structure control map)