### PR TITLE
Fix initial waterlevel file if it is empty string

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,11 @@ Changelog of threedi-modelchecker
 
 - Add dem_obstacle_detection != True check.
 
+- Added check on water_level_ini_type.
+
+- Interpret empty strings the same as NULL in initial (groundwater) level file
+  fields (simulation template worker).
+
 
 0.23 (2022-01-11)
 -----------------

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -737,6 +737,15 @@ CHECKS += [
         ),
         message="sub-basins (v2_global_settings.manhole_storage_area > 0) should only be used when there is no DEM supplied and there is no 2D flow",
     ),
+    QueryCheck(
+        error_code=322,
+        column=models.GlobalSetting.water_level_ini_type,
+        invalid=Query(models.GroundWater).filter(
+            ~is_none_or_empty(models.GlobalSetting.initial_waterlevel_file),
+            models.GlobalSetting.water_level_ini_type == None,
+        ),
+        message="an initial waterlevel type (v2_groundwater.water_level_ini_type) should be defined when using an initial waterlevel file.",
+    ),
 ]
 
 ## 04xx: Groundwater, Interflow & Infiltration

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -744,7 +744,7 @@ CHECKS += [
             ~is_none_or_empty(models.GlobalSetting.initial_waterlevel_file),
             models.GlobalSetting.water_level_ini_type == None,
         ),
-        message="an initial waterlevel type (v2_groundwater.water_level_ini_type) should be defined when using an initial waterlevel file.",
+        message="an initial waterlevel type (v2_global_settings.water_level_ini_type) should be defined when using an initial waterlevel file.",
     ),
 ]
 

--- a/threedi_modelchecker/simulation_templates/initial_waterlevels/extractor.py
+++ b/threedi_modelchecker/simulation_templates/initial_waterlevels/extractor.py
@@ -1,3 +1,4 @@
+from ..exceptions import SchematisationError
 from sqlalchemy.orm import Query
 from sqlalchemy.orm.session import Session
 from threedi_api_client.openapi.models import GroundWaterRaster
@@ -61,7 +62,7 @@ class InitialWaterlevelExtractor(object):
     def constant_waterlevel_2d(self) -> Optional[TwoDWaterLevel]:
         if self.global_settings.initial_waterlevel is None:
             return None
-        if self.global_settings.initial_waterlevel_file is not None:
+        if self.global_settings.initial_waterlevel_file:
             return None
         if float(self.global_settings.initial_waterlevel) == -9999:
             return None
@@ -70,6 +71,8 @@ class InitialWaterlevelExtractor(object):
     @property
     def constant_waterlevel_groundwater(self) -> Optional[GroundWaterLevel]:
         if self.global_settings.initial_groundwater_level is None:
+            return None
+        if self.global_settings.initial_groundwater_level_file:
             return None
         if float(self.global_settings.initial_groundwater_level) == -9999:
             return None
@@ -85,11 +88,12 @@ class InitialWaterlevelExtractor(object):
 
     @property
     def waterlevel_2d_raster(self) -> Optional[TwoDWaterRaster]:
-        if (
-            self.global_settings.initial_waterlevel_file is None
-            or self.global_settings.water_level_ini_type is None
-        ):
+        if not self.global_settings.initial_waterlevel_file:
             return None
+        if self.global_settings.water_level_ini_type is None:
+            raise SchematisationError(
+                "initial_waterlevel_file supplied without water_level_ini_type"
+            )
         return TwoDWaterRaster(
             aggregation_method=sqlite_agg_method_to_api_map[
                 self.global_settings.water_level_ini_type.value
@@ -99,11 +103,12 @@ class InitialWaterlevelExtractor(object):
 
     @property
     def waterlevel_groundwater_raster(self) -> Optional[GroundWaterRaster]:
-        if (
-            self.global_settings.initial_groundwater_level_file is None
-            or self.global_settings.initial_groundwater_level_type is None
-        ):
+        if not self.global_settings.initial_groundwater_level_file:
             return None
+        if self.global_settings.initial_groundwater_level_type is None:
+            raise SchematisationError(
+                "initial_groundwater_level_file supplied without initial_groundwater_level_type"
+            )
         return GroundWaterRaster(
             aggregation_method=sqlite_agg_method_to_api_map[
                 self.global_settings.initial_groundwater_level_type.value


### PR DESCRIPTION
The issue was that empty strings were interpreted as "no file" in the modelchecker, but not in the template worker.

The water_level_ini_type is compulsory, I checked all existing models and each of them has the water_level_ini_type filled if initial_waterlevel is supplied.

The same story for groundwater, only there the check on initial_groundwater_level_type was already there.

