### PR TITLE
Allow isolated unconnected manholes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog of threedi-modelchecker
 0.24.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Allow isolated manholes that are not connected to anything (emit warning instead
+  of error).
 
 
 0.24.1 (2022-01-17)

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -520,6 +520,7 @@ CHECKS += [
 CHECKS += [
     QueryCheck(
         error_code=251,
+        level=CheckLevel.WARNING,
         column=models.ConnectionNode.id,
         invalid=Query(models.ConnectionNode)
         .join(models.Manhole)


### PR DESCRIPTION
@martijn-siemerink  For instance hekerbeekdal has this issue, while there are no numerical problems. @Jonasvsl thinks it is better to make this a warning and don't block threedimodel creation if this happens.