### PR TITLE
[DONE] Globalsettingoptions include start_datetime and duration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,7 @@ Changelog of threedi-modelchecker
 0.25.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Try to add `start_datetime` and `duration` to a `GlobalSettingOption`
 
 0.25.2 (2022-01-26)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@ Changelog of threedi-modelchecker
 =================================
 
 
+0.25.3 (unreleased)
+-------------------
+
+- Nothing changed yet.
+
+
 0.25.2 (2022-01-26)
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ tests_require = [
     "aiohttp",
     "pytest-asyncio",
     "numpy",
+    "python-dateutil"
 ]
 
 simulation_templates_require = [
@@ -29,6 +30,7 @@ simulation_templates_require = [
     "threedi-api-client>=4.0.0b2",
     "aiofiles",
     "aiohttp",
+    "python-dateutil"
 ]
 
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -20,7 +20,7 @@ class GlobalSettingsFactory(factory.alchemy.SQLAlchemyModelFactory):
     grid_space = 20
     advection_2d = 1
     dist_calc_points = 15
-    start_date = datetime.datetime.now()
+    start_date = datetime.datetime.now().isoformat()
     table_step_size = 0.05
     use_1d_flow = False
     use_2d_rain = 1

--- a/threedi_modelchecker/__init__.py
+++ b/threedi_modelchecker/__init__.py
@@ -3,5 +3,5 @@ from .threedi_database import *  # NOQA
 
 
 # fmt: off
-__version__ = '0.25.2'
+__version__ = '0.25.3.dev0'
 # fmt: on

--- a/threedi_modelchecker/simulation_templates/extractor.py
+++ b/threedi_modelchecker/simulation_templates/extractor.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from sqlalchemy.orm import Query
 from sqlalchemy.orm.session import Session
 from datetime import datetime, timezone
+from dateutil import parser
 from threedi_modelchecker.simulation_templates.boundaries.extractor import (
     BoundariesExtractor,
 )
@@ -44,11 +45,11 @@ def parse_datetime(global_setting: GlobalSetting) -> Optional[datetime]:
         options.append(f"{global_setting.start_time}")
     if global_setting.start_date:
         options.append(f"{global_setting.start_date}")
-        
+
     dt = None
     for option in options:
         try:
-            dt = datetime.fromisoformat(option)
+            dt = parser.parse(option)
         except (ValueError, TypeError):
             dt = None
         if dt:

--- a/threedi_modelchecker/simulation_templates/extractor.py
+++ b/threedi_modelchecker/simulation_templates/extractor.py
@@ -37,11 +37,16 @@ __all__ = ["SimulationTemplateExtractor"]
 
 def parse_datetime(global_setting: GlobalSetting) -> Optional[datetime]:
     # first try combination, than start_time than start_date
-    for option in [
-        global_setting.start_date + " " + global_setting.start_time,
-        global_setting.start_time,
-        global_setting.start_date,
-    ]:
+    options = []
+    if global_setting.start_date and global_setting.start_time:
+        options.append(f"{global_setting.start_date} {global_setting.start_time}")
+    if global_setting.start_time:
+        options.append(f"{global_setting.start_time}")
+    if global_setting.start_date:
+        options.append(f"{global_setting.start_date}")
+        
+    dt = None
+    for option in options:
         try:
             dt = datetime.fromisoformat(option)
         except (ValueError, TypeError):

--- a/threedi_modelchecker/simulation_templates/models.py
+++ b/threedi_modelchecker/simulation_templates/models.py
@@ -5,6 +5,7 @@ from dataclasses import fields
 from dataclasses import InitVar
 from enum import Enum
 from io import BytesIO
+from datetime import datetime
 from threedi_api_client.aio.files import upload_fileobj
 from threedi_api_client.openapi.models import AggregationSettings
 from threedi_api_client.openapi.models import FileLateral
@@ -79,6 +80,11 @@ class GlobalSettingOption:
 
     id: int  # v2_global_settings.id
     name: str
+
+    # derived start_datetime and duration from global settings
+    # might be None
+    start_datetime: Optional[datetime] = None
+    duration: Optional[int] = None
 
 
 class AsyncBytesIO:


### PR DESCRIPTION
Allows to set the start_datetime and duration of a simulation_template to values in first global settings entry.
Note that these values need to be overriden when creating a simulation from a template, but even so these are
used as defaults in the modeller interface, so better to have good values.

Note: All file uploads don't have `within simulation.duration` validation. So for simulation templates this should not cause any validation problems.