### PR TITLE
Drop NOT NULL and other constraints

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ Changelog of threedi-modelchecker
 
 - Run unittests on spatialite 3 and 4.
 
+- Improved performance of upgrading an empty database.
+
+- Remove all NOT NULL, unique, and foreign key constraints in the spatialite.
+
 
 0.26.1 (2022-04-11)
 -------------------

--- a/tests/test_spatalite_versions.py
+++ b/tests/test_spatalite_versions.py
@@ -69,17 +69,3 @@ def test_copy_invalid_geometry(empty_sqlite_v3, empty_sqlite_v4):
         )
 
         assert records == [(3, "POLYGON((0 0, 10 10, 0 10, 10 0, 0 0))")]
-
-
-def test_copy_violates_null_constraint(empty_sqlite_v3, empty_sqlite_v4):
-    """Copying an invalid geometry (ST_IsValid evaluates to False) is possible"""
-    db_from = empty_sqlite_v3
-    db_to = empty_sqlite_v4
-
-    obj = models.Manhole(id=3, code="test", display_name="test", connection_node_id=1)
-    with db_from.session_scope() as session:
-        session.add(obj)
-        session.commit()
-
-    with pytest.raises(UpgradeFailedError, match="NOT NULL constraint failed: v2_manhole.bottom_level"):
-        copy_model(db_from, db_to, models.Manhole)

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -527,7 +527,9 @@ CHECKS += [
     QueryCheck(
         error_code=206,
         column=models.ConnectionNode.the_geom_linestring,
-        invalid=Query(models.ConnectionNode).filter(models.ConnectionNode.the_geom_linestring != None),
+        invalid=Query(models.ConnectionNode).filter(
+            models.ConnectionNode.the_geom_linestring != None
+        ),
         message="The 'the_geom_linestring' column of v2_connection_nodes must be NULL",
     )
 ]
@@ -1492,14 +1494,8 @@ class Config:
                 error_code=1,
             )
             self.checks += generate_unique_checks(model.__table__, error_code=2)
-            self.checks += generate_not_null_checks(
-                model.__table__,
-                error_code=3
-            )
-            self.checks += generate_type_checks(
-                model.__table__,
-                error_code=4
-            )
+            self.checks += generate_not_null_checks(model.__table__, error_code=3)
+            self.checks += generate_type_checks(model.__table__, error_code=4)
             self.checks += generate_geometry_checks(
                 model.__table__,
                 custom_level_map={

--- a/threedi_modelchecker/migrations/versions/0200_initial.py
+++ b/threedi_modelchecker/migrations/versions/0200_initial.py
@@ -94,9 +94,6 @@ def upgrade_163():
 
     op.execute("UPDATE v2_global_settings SET use_2d_rain = 1")
 
-    with op.batch_alter_table("v2_global_settings") as batch_op:
-        batch_op.alter_column("use_2d_rain", nullable=False)
-
 
 def upgrade_164():
     """This implements a migration from the old stack:
@@ -105,9 +102,9 @@ def upgrade_164():
     """
     create_table_if_not_exists(
         "v2_grid_refinement_area",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("display_name", sa.String(length=255), nullable=True),
-        sa.Column("refinement_level", sa.Integer(), nullable=False),
+        sa.Column("refinement_level", sa.Integer(), nullable=True),
         sa.Column("code", sa.String(length=100), nullable=True),
         sa.Column(
             "the_geom",
@@ -116,7 +113,7 @@ def upgrade_164():
                 srid=4326,
                 management=True,
             ),
-            nullable=False,
+            nullable=True,
         ),
         sa.PrimaryKeyConstraint("id"),
     )
@@ -129,7 +126,7 @@ def upgrade_165():
     """
     create_table_if_not_exists(
         "v2_groundwater",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("groundwater_impervious_layer_level", sa.Float(), nullable=True),
         sa.Column(
             "groundwater_impervious_layer_level_file",
@@ -172,7 +169,7 @@ def upgrade_165():
 
     create_table_if_not_exists(
         "v2_simple_infiltration",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("infiltration_rate", sa.Float(), nullable=True),
         sa.Column("infiltration_rate_file", sa.String(length=255), nullable=True),
         sa.Column("infiltration_surface_option", sa.Integer(), nullable=True),
@@ -183,8 +180,8 @@ def upgrade_165():
 
     create_table_if_not_exists(
         "v2_interflow",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("interflow_type", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("interflow_type", sa.Integer(), nullable=True),
         sa.Column("porosity", sa.Float(), nullable=True),
         sa.Column("porosity_file", sa.String(length=255), nullable=True),
         sa.Column("porosity_layer_thickness", sa.Float(), nullable=True),
@@ -310,10 +307,6 @@ def upgrade_171():
         "UPDATE v2_culvert SET discharge_coefficient_positive = 1.0 WHERE discharge_coefficient_positive IS NULL"
     )
 
-    with op.batch_alter_table("v2_culvert") as batch_op:
-        batch_op.alter_column("discharge_coefficient_negative", nullable=False)
-        batch_op.alter_column("discharge_coefficient_positive", nullable=False)
-
 
 def upgrade_172():
     """This implements a migration from the old stack:
@@ -385,10 +378,10 @@ def upgrade():
 
     create_table_if_not_exists(
         "v2_2d_boundary_conditions",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("display_name", sa.String(length=255), nullable=True),
         sa.Column("timeseries", sa.Text(), nullable=True),
-        sa.Column("boundary_type", sa.Integer(), nullable=False),
+        sa.Column("boundary_type", sa.Integer(), nullable=True),
         sa.Column(
             "the_geom",
             geoalchemy2.types.Geometry(
@@ -396,14 +389,14 @@ def upgrade():
                 srid=4326,
                 management=True,
             ),
-            nullable=False,
+            nullable=True,
         ),
         sa.PrimaryKeyConstraint("id"),
     )
     create_table_if_not_exists(
         "v2_2d_lateral",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("type", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("type", sa.Integer(), nullable=True),
         sa.Column(
             "the_geom",
             geoalchemy2.types.Geometry(
@@ -411,16 +404,16 @@ def upgrade():
                 srid=4326,
                 management=True,
             ),
-            nullable=False,
+            nullable=True,
         ),
-        sa.Column("timeseries", sa.Text(), nullable=False),
+        sa.Column("timeseries", sa.Text(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
     )
     create_table_if_not_exists(
         "v2_calculation_point",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("content_type_id", sa.Integer(), nullable=True),
-        sa.Column("user_ref", sa.String(length=80), nullable=False),
+        sa.Column("user_ref", sa.String(length=80), nullable=True),
         sa.Column("calc_type", sa.Integer(), nullable=True),
         sa.Column(
             "the_geom",
@@ -429,13 +422,13 @@ def upgrade():
                 srid=4326,
                 management=True,
             ),
-            nullable=False,
+            nullable=True,
         ),
         sa.PrimaryKeyConstraint("id"),
     )
     create_table_if_not_exists(
         "v2_connection_nodes",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("storage_area", sa.Float(), nullable=True),
         sa.Column("initial_waterlevel", sa.Float(), nullable=True),
         sa.Column(
@@ -445,7 +438,7 @@ def upgrade():
                 srid=4326,
                 management=True,
             ),
-            nullable=False,
+            nullable=True,
         ),
         sa.Column(
             "the_geom_linestring",
@@ -461,7 +454,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_control_delta",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("measure_variable", sa.String(length=50), nullable=True),
         sa.Column("measure_delta", sa.String(length=50), nullable=True),
         sa.Column("measure_dt", sa.Float(), nullable=True),
@@ -474,19 +467,19 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_control_group",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("name", sa.String(length=100), nullable=True),
         sa.Column("description", sa.Text(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
     )
     create_table_if_not_exists(
         "v2_control_measure_group",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
     )
     create_table_if_not_exists(
         "v2_control_memory",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("measure_variable", sa.String(length=50), nullable=True),
         sa.Column("upper_threshold", sa.Float(), nullable=True),
         sa.Column("lower_threshold", sa.Float(), nullable=True),
@@ -494,13 +487,13 @@ def upgrade():
         sa.Column("action_value", sa.String(length=50), nullable=True),
         sa.Column("target_type", sa.String(length=100), nullable=True),
         sa.Column("target_id", sa.Integer(), nullable=True),
-        sa.Column("is_active", sa.Boolean(), nullable=False),
-        sa.Column("is_inverse", sa.Boolean(), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=True),
+        sa.Column("is_inverse", sa.Boolean(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
     )
     create_table_if_not_exists(
         "v2_control_pid",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("measure_variable", sa.String(length=50), nullable=True),
         sa.Column("setpoint", sa.Float(), nullable=True),
         sa.Column("kp", sa.Float(), nullable=True),
@@ -514,7 +507,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_control_table",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("action_table", sa.Text(), nullable=True),
         sa.Column("action_type", sa.String(length=50), nullable=True),
         sa.Column("measure_variable", sa.String(length=50), nullable=True),
@@ -525,7 +518,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_control_timed",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("action_type", sa.String(length=50), nullable=True),
         sa.Column("action_table", sa.Text(), nullable=True),
         sa.Column("target_type", sa.String(length=100), nullable=True),
@@ -534,7 +527,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_cross_section_definition",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("width", sa.String(length=255), nullable=True),
         sa.Column("height", sa.String(length=255), nullable=True),
         sa.Column("shape", sa.Integer(), nullable=True),
@@ -543,7 +536,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_dem_average_area",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column(
             "the_geom",
             geoalchemy2.types.Geometry(
@@ -551,13 +544,13 @@ def upgrade():
                 srid=4326,
                 management=True,
             ),
-            nullable=False,
+            nullable=True,
         ),
         sa.PrimaryKeyConstraint("id"),
     )
     create_table_if_not_exists(
         "v2_floodfill",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("waterlevel", sa.Float(), nullable=True),
         sa.Column(
             "the_geom",
@@ -572,9 +565,9 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_grid_refinement",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("display_name", sa.String(length=255), nullable=True),
-        sa.Column("refinement_level", sa.Integer(), nullable=False),
+        sa.Column("refinement_level", sa.Integer(), nullable=True),
         sa.Column(
             "the_geom",
             geoalchemy2.types.Geometry(
@@ -582,16 +575,16 @@ def upgrade():
                 srid=4326,
                 management=True,
             ),
-            nullable=False,
+            nullable=True,
         ),
         sa.Column("code", sa.String(length=100), nullable=True),
         sa.PrimaryKeyConstraint("id"),
     )
     create_table_if_not_exists(
         "v2_grid_refinement_area",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("display_name", sa.String(length=255), nullable=True),
-        sa.Column("refinement_level", sa.Integer(), nullable=False),
+        sa.Column("refinement_level", sa.Integer(), nullable=True),
         sa.Column("code", sa.String(length=100), nullable=True),
         sa.Column(
             "the_geom",
@@ -600,13 +593,13 @@ def upgrade():
                 srid=4326,
                 management=True,
             ),
-            nullable=False,
+            nullable=True,
         ),
         sa.PrimaryKeyConstraint("id"),
     )
     create_table_if_not_exists(
         "v2_groundwater",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("groundwater_impervious_layer_level", sa.Float(), nullable=True),
         sa.Column(
             "groundwater_impervious_layer_level_file",
@@ -648,11 +641,11 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_impervious_surface",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("code", sa.String(length=100), nullable=True),
         sa.Column("display_name", sa.String(length=255), nullable=True),
-        sa.Column("surface_inclination", sa.String(length=64), nullable=False),
-        sa.Column("surface_class", sa.String(length=128), nullable=False),
+        sa.Column("surface_inclination", sa.String(length=64), nullable=True),
+        sa.Column("surface_class", sa.String(length=128), nullable=True),
         sa.Column("surface_sub_class", sa.String(length=128), nullable=True),
         sa.Column("zoom_category", sa.Integer(), nullable=True),
         sa.Column("nr_of_inhabitants", sa.Float(), nullable=True),
@@ -671,8 +664,8 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_interflow",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("interflow_type", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("interflow_type", sa.Integer(), nullable=True),
         sa.Column("porosity", sa.Float(), nullable=True),
         sa.Column("porosity_file", sa.String(length=255), nullable=True),
         sa.Column("porosity_layer_thickness", sa.Float(), nullable=True),
@@ -684,7 +677,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_levee",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("code", sa.String(length=100), nullable=True),
         sa.Column("crest_level", sa.Float(), nullable=True),
         sa.Column(
@@ -694,7 +687,7 @@ def upgrade():
                 srid=4326,
                 management=True,
             ),
-            nullable=False,
+            nullable=True,
         ),
         sa.Column("material", sa.Integer(), nullable=True),
         sa.Column("max_breach_depth", sa.Float(), nullable=True),
@@ -702,7 +695,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_numerical_settings",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("cfl_strictness_factor_1d", sa.Float(), nullable=True),
         sa.Column("cfl_strictness_factor_2d", sa.Float(), nullable=True),
         sa.Column("convergence_cg", sa.Float(), nullable=True),
@@ -716,22 +709,22 @@ def upgrade():
         sa.Column("limiter_slope_crossectional_area_2d", sa.Integer(), nullable=True),
         sa.Column("limiter_slope_friction_2d", sa.Integer(), nullable=True),
         sa.Column("max_nonlin_iterations", sa.Integer(), nullable=True),
-        sa.Column("max_degree", sa.Integer(), nullable=False),
+        sa.Column("max_degree", sa.Integer(), nullable=True),
         sa.Column("minimum_friction_velocity", sa.Float(), nullable=True),
         sa.Column("minimum_surface_area", sa.Float(), nullable=True),
         sa.Column("precon_cg", sa.Integer(), nullable=True),
         sa.Column("preissmann_slot", sa.Float(), nullable=True),
         sa.Column("pump_implicit_ratio", sa.Float(), nullable=True),
         sa.Column("thin_water_layer_definition", sa.Float(), nullable=True),
-        sa.Column("use_of_cg", sa.Integer(), nullable=False),
-        sa.Column("use_of_nested_newton", sa.Integer(), nullable=False),
+        sa.Column("use_of_cg", sa.Integer(), nullable=True),
+        sa.Column("use_of_nested_newton", sa.Integer(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
     )
     create_table_if_not_exists(
         "v2_obstacle",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("code", sa.String(length=100), nullable=True),
-        sa.Column("crest_level", sa.Float(), nullable=False),
+        sa.Column("crest_level", sa.Float(), nullable=True),
         sa.Column(
             "the_geom",
             geoalchemy2.types.Geometry(
@@ -739,13 +732,13 @@ def upgrade():
                 srid=4326,
                 management=True,
             ),
-            nullable=False,
+            nullable=True,
         ),
         sa.PrimaryKeyConstraint("id"),
     )
     create_table_if_not_exists(
         "v2_simple_infiltration",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("infiltration_rate", sa.Float(), nullable=True),
         sa.Column("infiltration_rate_file", sa.String(length=255), nullable=True),
         sa.Column("infiltration_surface_option", sa.Integer(), nullable=True),
@@ -755,38 +748,38 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_surface_parameters",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("outflow_delay", sa.Float(), nullable=False),
-        sa.Column("surface_layer_thickness", sa.Float(), nullable=False),
-        sa.Column("infiltration", sa.Boolean(), nullable=False),
-        sa.Column("max_infiltration_capacity", sa.Float(), nullable=False),
-        sa.Column("min_infiltration_capacity", sa.Float(), nullable=False),
-        sa.Column("infiltration_decay_constant", sa.Float(), nullable=False),
-        sa.Column("infiltration_recovery_constant", sa.Float(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("outflow_delay", sa.Float(), nullable=True),
+        sa.Column("surface_layer_thickness", sa.Float(), nullable=True),
+        sa.Column("infiltration", sa.Boolean(), nullable=True),
+        sa.Column("max_infiltration_capacity", sa.Float(), nullable=True),
+        sa.Column("min_infiltration_capacity", sa.Float(), nullable=True),
+        sa.Column("infiltration_decay_constant", sa.Float(), nullable=True),
+        sa.Column("infiltration_recovery_constant", sa.Float(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
     )
     create_table_if_not_exists(
         "v2_1d_boundary_conditions",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("boundary_type", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("boundary_type", sa.Integer(), nullable=True),
         sa.Column("timeseries", sa.Text(), nullable=True),
-        sa.Column("connection_node_id", sa.Integer(), nullable=False),
+        sa.Column("connection_node_id", sa.Integer(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("connection_node_id"),
     )
     create_table_if_not_exists(
         "v2_1d_lateral",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("connection_node_id", sa.Integer(), nullable=False),
-        sa.Column("timeseries", sa.Text(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("connection_node_id", sa.Integer(), nullable=True),
+        sa.Column("timeseries", sa.Text(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
     )
     create_table_if_not_exists(
         "v2_channel",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("display_name", sa.String(length=255), nullable=True),
         sa.Column("code", sa.String(length=100), nullable=True),
-        sa.Column("calculation_type", sa.Integer(), nullable=False),
+        sa.Column("calculation_type", sa.Integer(), nullable=True),
         sa.Column("dist_calc_points", sa.Float(), nullable=True),
         sa.Column("zoom_category", sa.Integer(), nullable=True),
         sa.Column(
@@ -796,16 +789,16 @@ def upgrade():
                 srid=4326,
                 management=True,
             ),
-            nullable=False,
+            nullable=True,
         ),
-        sa.Column("connection_node_start_id", sa.Integer(), nullable=False),
-        sa.Column("connection_node_end_id", sa.Integer(), nullable=False),
+        sa.Column("connection_node_start_id", sa.Integer(), nullable=True),
+        sa.Column("connection_node_end_id", sa.Integer(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
     )
     create_table_if_not_exists(
         "v2_connected_pnt",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("calculation_pnt_id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("calculation_pnt_id", sa.Integer(), nullable=True),
         sa.Column("levee_id", sa.Integer(), nullable=True),
         sa.Column("exchange_level", sa.Float(), nullable=True),
         sa.Column(
@@ -815,13 +808,13 @@ def upgrade():
                 srid=4326,
                 management=True,
             ),
-            nullable=False,
+            nullable=True,
         ),
         sa.PrimaryKeyConstraint("id"),
     )
     create_table_if_not_exists(
         "v2_control",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("control_group_id", sa.Integer(), nullable=True),
         sa.Column("measure_group_id", sa.Integer(), nullable=True),
         sa.Column("control_type", sa.String(length=15), nullable=True),
@@ -833,7 +826,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_control_measure_map",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("measure_group_id", sa.Integer(), nullable=True),
         sa.Column("object_type", sa.String(length=100), nullable=True),
         sa.Column("object_id", sa.Integer(), nullable=True),
@@ -842,18 +835,18 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_culvert",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("display_name", sa.String(length=255), nullable=True),
         sa.Column("code", sa.String(length=100), nullable=True),
         sa.Column("calculation_type", sa.Integer(), nullable=True),
-        sa.Column("friction_value", sa.Float(), nullable=False),
-        sa.Column("friction_type", sa.Integer(), nullable=False),
+        sa.Column("friction_value", sa.Float(), nullable=True),
+        sa.Column("friction_type", sa.Integer(), nullable=True),
         sa.Column("dist_calc_points", sa.Float(), nullable=True),
         sa.Column("zoom_category", sa.Integer(), nullable=True),
         sa.Column("discharge_coefficient_positive", sa.Float(), nullable=True),
         sa.Column("discharge_coefficient_negative", sa.Float(), nullable=True),
-        sa.Column("invert_level_start_point", sa.Float(), nullable=False),
-        sa.Column("invert_level_end_point", sa.Float(), nullable=False),
+        sa.Column("invert_level_start_point", sa.Float(), nullable=True),
+        sa.Column("invert_level_end_point", sa.Float(), nullable=True),
         sa.Column(
             "the_geom",
             geoalchemy2.types.Geometry(
@@ -863,45 +856,45 @@ def upgrade():
             ),
             nullable=True,
         ),
-        sa.Column("connection_node_start_id", sa.Integer(), nullable=False),
-        sa.Column("connection_node_end_id", sa.Integer(), nullable=False),
-        sa.Column("cross_section_definition_id", sa.Integer(), nullable=False),
+        sa.Column("connection_node_start_id", sa.Integer(), nullable=True),
+        sa.Column("connection_node_end_id", sa.Integer(), nullable=True),
+        sa.Column("cross_section_definition_id", sa.Integer(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
     )
     create_table_if_not_exists(
         "v2_global_settings",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("use_2d_flow", sa.Boolean(), nullable=False),
-        sa.Column("use_1d_flow", sa.Boolean(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("use_2d_flow", sa.Boolean(), nullable=True),
+        sa.Column("use_1d_flow", sa.Boolean(), nullable=True),
         sa.Column("manhole_storage_area", sa.Float(), nullable=True),
         sa.Column("name", sa.String(length=128), nullable=True),
-        sa.Column("sim_time_step", sa.Float(), nullable=False),
+        sa.Column("sim_time_step", sa.Float(), nullable=True),
         sa.Column("output_time_step", sa.Float(), nullable=True),
-        sa.Column("nr_timesteps", sa.Integer(), nullable=False),
+        sa.Column("nr_timesteps", sa.Integer(), nullable=True),
         sa.Column("start_time", sa.Text(), nullable=True),
-        sa.Column("start_date", sa.Text(), nullable=False),
-        sa.Column("grid_space", sa.Float(), nullable=False),
-        sa.Column("dist_calc_points", sa.Float(), nullable=False),
-        sa.Column("kmax", sa.Integer(), nullable=False),
+        sa.Column("start_date", sa.Text(), nullable=True),
+        sa.Column("grid_space", sa.Float(), nullable=True),
+        sa.Column("dist_calc_points", sa.Float(), nullable=True),
+        sa.Column("kmax", sa.Integer(), nullable=True),
         sa.Column("guess_dams", sa.Integer(), nullable=True),
-        sa.Column("table_step_size", sa.Float(), nullable=False),
-        sa.Column("flooding_threshold", sa.Float(), nullable=False),
-        sa.Column("advection_1d", sa.Integer(), nullable=False),
-        sa.Column("advection_2d", sa.Integer(), nullable=False),
+        sa.Column("table_step_size", sa.Float(), nullable=True),
+        sa.Column("flooding_threshold", sa.Float(), nullable=True),
+        sa.Column("advection_1d", sa.Integer(), nullable=True),
+        sa.Column("advection_2d", sa.Integer(), nullable=True),
         sa.Column("dem_file", sa.String(length=255), nullable=True),
         sa.Column("frict_type", sa.Integer(), nullable=True),
-        sa.Column("frict_coef", sa.Float(), nullable=False),
+        sa.Column("frict_coef", sa.Float(), nullable=True),
         sa.Column("frict_coef_file", sa.String(length=255), nullable=True),
         sa.Column("water_level_ini_type", sa.Integer(), nullable=True),
-        sa.Column("initial_waterlevel", sa.Float(), nullable=False),
+        sa.Column("initial_waterlevel", sa.Float(), nullable=True),
         sa.Column("initial_waterlevel_file", sa.String(length=255), nullable=True),
         sa.Column("interception_global", sa.Float(), nullable=True),
         sa.Column("interception_file", sa.String(length=255), nullable=True),
-        sa.Column("dem_obstacle_detection", sa.Boolean(), nullable=False),
+        sa.Column("dem_obstacle_detection", sa.Boolean(), nullable=True),
         sa.Column("dem_obstacle_height", sa.Float(), nullable=True),
         sa.Column("embedded_cutoff_threshold", sa.Float(), nullable=True),
         sa.Column("epsg_code", sa.Integer(), nullable=True),
-        sa.Column("timestep_plus", sa.Boolean(), nullable=False),
+        sa.Column("timestep_plus", sa.Boolean(), nullable=True),
         sa.Column("max_angle_1d_advection", sa.Float(), nullable=True),
         sa.Column("minimum_sim_time_step", sa.Float(), nullable=True),
         sa.Column("maximum_sim_time_step", sa.Float(), nullable=True),
@@ -910,13 +903,13 @@ def upgrade():
         sa.Column("use_0d_inflow", sa.Integer(), nullable=True),
         sa.Column("table_step_size_1d", sa.Float(), nullable=True),
         sa.Column("table_step_size_volume_2d", sa.Float(), nullable=True),
-        sa.Column("use_2d_rain", sa.Integer(), nullable=False),
+        sa.Column("use_2d_rain", sa.Integer(), nullable=True),
         sa.Column("initial_groundwater_level", sa.Float(), nullable=True),
         sa.Column(
             "initial_groundwater_level_file", sa.String(length=255), nullable=True
         ),
         sa.Column("initial_groundwater_level_type", sa.Integer(), nullable=True),
-        sa.Column("numerical_settings_id", sa.Integer(), nullable=False),
+        sa.Column("numerical_settings_id", sa.Integer(), nullable=True),
         sa.Column("interflow_settings_id", sa.Integer(), nullable=True),
         sa.Column("control_group_id", sa.Integer(), nullable=True),
         sa.Column("simple_infiltration_settings_id", sa.Integer(), nullable=True),
@@ -925,15 +918,15 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_impervious_surface_map",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("percentage", sa.Float(), nullable=False),
-        sa.Column("impervious_surface_id", sa.Integer(), nullable=False),
-        sa.Column("connection_node_id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("percentage", sa.Float(), nullable=True),
+        sa.Column("impervious_surface_id", sa.Integer(), nullable=True),
+        sa.Column("connection_node_id", sa.Integer(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
     )
     create_table_if_not_exists(
         "v2_manhole",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("display_name", sa.String(length=255), nullable=True),
         sa.Column("code", sa.String(length=100), nullable=True),
         sa.Column("zoom_category", sa.Integer(), nullable=True),
@@ -941,73 +934,73 @@ def upgrade():
         sa.Column("width", sa.Float(), nullable=True),
         sa.Column("length", sa.Float(), nullable=True),
         sa.Column("surface_level", sa.Float(), nullable=True),
-        sa.Column("bottom_level", sa.Float(), nullable=False),
+        sa.Column("bottom_level", sa.Float(), nullable=True),
         sa.Column("drain_level", sa.Float(), nullable=True),
         sa.Column("sediment_level", sa.Float(), nullable=True),
         sa.Column("manhole_indicator", sa.Integer(), nullable=True),
         sa.Column("calculation_type", sa.Integer(), nullable=True),
-        sa.Column("connection_node_id", sa.Integer(), nullable=False),
+        sa.Column("connection_node_id", sa.Integer(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
     )
     create_table_if_not_exists(
         "v2_orifice",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("code", sa.String(length=100), nullable=True),
         sa.Column("display_name", sa.String(length=255), nullable=True),
         sa.Column("zoom_category", sa.Integer(), nullable=True),
-        sa.Column("crest_type", sa.Integer(), nullable=False),
-        sa.Column("crest_level", sa.Float(), nullable=False),
+        sa.Column("crest_type", sa.Integer(), nullable=True),
+        sa.Column("crest_level", sa.Float(), nullable=True),
         sa.Column("friction_value", sa.Float(), nullable=True),
         sa.Column("friction_type", sa.Integer(), nullable=True),
         sa.Column("discharge_coefficient_positive", sa.Float(), nullable=True),
         sa.Column("discharge_coefficient_negative", sa.Float(), nullable=True),
-        sa.Column("sewerage", sa.Boolean(), nullable=False),
-        sa.Column("connection_node_start_id", sa.Integer(), nullable=False),
-        sa.Column("connection_node_end_id", sa.Integer(), nullable=False),
-        sa.Column("cross_section_definition_id", sa.Integer(), nullable=False),
+        sa.Column("sewerage", sa.Boolean(), nullable=True),
+        sa.Column("connection_node_start_id", sa.Integer(), nullable=True),
+        sa.Column("connection_node_end_id", sa.Integer(), nullable=True),
+        sa.Column("cross_section_definition_id", sa.Integer(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
     )
     create_table_if_not_exists(
         "v2_pipe",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("display_name", sa.String(length=255), nullable=True),
         sa.Column("code", sa.String(length=100), nullable=True),
         sa.Column("profile_num", sa.Integer(), nullable=True),
         sa.Column("sewerage_type", sa.Integer(), nullable=True),
-        sa.Column("calculation_type", sa.Integer(), nullable=False),
-        sa.Column("invert_level_start_point", sa.Float(), nullable=False),
-        sa.Column("invert_level_end_point", sa.Float(), nullable=False),
-        sa.Column("friction_value", sa.Float(), nullable=False),
-        sa.Column("friction_type", sa.Integer(), nullable=False),
+        sa.Column("calculation_type", sa.Integer(), nullable=True),
+        sa.Column("invert_level_start_point", sa.Float(), nullable=True),
+        sa.Column("invert_level_end_point", sa.Float(), nullable=True),
+        sa.Column("friction_value", sa.Float(), nullable=True),
+        sa.Column("friction_type", sa.Integer(), nullable=True),
         sa.Column("dist_calc_points", sa.Float(), nullable=True),
         sa.Column("material", sa.Integer(), nullable=True),
         sa.Column("original_length", sa.Float(), nullable=True),
         sa.Column("zoom_category", sa.Integer(), nullable=True),
-        sa.Column("connection_node_start_id", sa.Integer(), nullable=False),
-        sa.Column("connection_node_end_id", sa.Integer(), nullable=False),
-        sa.Column("cross_section_definition_id", sa.Integer(), nullable=False),
+        sa.Column("connection_node_start_id", sa.Integer(), nullable=True),
+        sa.Column("connection_node_end_id", sa.Integer(), nullable=True),
+        sa.Column("cross_section_definition_id", sa.Integer(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
     )
     create_table_if_not_exists(
         "v2_pumpstation",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("code", sa.String(length=100), nullable=True),
         sa.Column("display_name", sa.String(length=255), nullable=True),
         sa.Column("zoom_category", sa.Integer(), nullable=True),
         sa.Column("classification", sa.Integer(), nullable=True),
         sa.Column("sewerage", sa.Boolean(), nullable=True),
-        sa.Column("type", sa.Integer(), nullable=False),
-        sa.Column("start_level", sa.Float(), nullable=False),
-        sa.Column("lower_stop_level", sa.Float(), nullable=False),
+        sa.Column("type", sa.Integer(), nullable=True),
+        sa.Column("start_level", sa.Float(), nullable=True),
+        sa.Column("lower_stop_level", sa.Float(), nullable=True),
         sa.Column("upper_stop_level", sa.Float(), nullable=True),
-        sa.Column("capacity", sa.Float(), nullable=False),
-        sa.Column("connection_node_start_id", sa.Integer(), nullable=False),
+        sa.Column("capacity", sa.Float(), nullable=True),
+        sa.Column("connection_node_start_id", sa.Integer(), nullable=True),
         sa.Column("connection_node_end_id", sa.Integer(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
     )
     create_table_if_not_exists(
         "v2_surface",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("display_name", sa.String(length=255), nullable=True),
         sa.Column("code", sa.String(length=100), nullable=True),
         sa.Column("zoom_category", sa.Integer(), nullable=True),
@@ -1015,7 +1008,7 @@ def upgrade():
         sa.Column("dry_weather_flow", sa.Float(), nullable=True),
         sa.Column("function", sa.String(length=64), nullable=True),
         sa.Column("area", sa.Float(), nullable=True),
-        sa.Column("surface_parameters_id", sa.Integer(), nullable=False),
+        sa.Column("surface_parameters_id", sa.Integer(), nullable=True),
         sa.Column(
             "the_geom",
             geoalchemy2.types.Geometry(
@@ -1029,20 +1022,20 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_surface_map",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("surface_type", sa.String(length=40), nullable=False),
-        sa.Column("surface_id", sa.Integer(), nullable=False),
-        sa.Column("connection_node_id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("surface_type", sa.String(length=40), nullable=True),
+        sa.Column("surface_id", sa.Integer(), nullable=True),
+        sa.Column("connection_node_id", sa.Integer(), nullable=True),
         sa.Column("percentage", sa.Float(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
     )
     create_table_if_not_exists(
         "v2_weir",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("code", sa.String(length=100), nullable=True),
         sa.Column("display_name", sa.String(length=255), nullable=True),
-        sa.Column("crest_level", sa.Float(), nullable=False),
-        sa.Column("crest_type", sa.Integer(), nullable=False),
+        sa.Column("crest_level", sa.Float(), nullable=True),
+        sa.Column("crest_type", sa.Integer(), nullable=True),
         sa.Column("friction_value", sa.Float(), nullable=True),
         sa.Column("friction_type", sa.Integer(), nullable=True),
         sa.Column("discharge_coefficient_positive", sa.Float(), nullable=True),
@@ -1050,29 +1043,29 @@ def upgrade():
         sa.Column("sewerage", sa.Boolean(), nullable=True),
         sa.Column("external", sa.Boolean(), nullable=True),
         sa.Column("zoom_category", sa.Integer(), nullable=True),
-        sa.Column("connection_node_start_id", sa.Integer(), nullable=False),
-        sa.Column("connection_node_end_id", sa.Integer(), nullable=False),
-        sa.Column("cross_section_definition_id", sa.Integer(), nullable=False),
+        sa.Column("connection_node_start_id", sa.Integer(), nullable=True),
+        sa.Column("connection_node_end_id", sa.Integer(), nullable=True),
+        sa.Column("cross_section_definition_id", sa.Integer(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
     )
     create_table_if_not_exists(
         "v2_aggregation_settings",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("global_settings_id", sa.Integer(), nullable=True),
-        sa.Column("var_name", sa.String(length=100), nullable=False),
-        sa.Column("flow_variable", sa.String(length=100), nullable=False),
+        sa.Column("var_name", sa.String(length=100), nullable=True),
+        sa.Column("flow_variable", sa.String(length=100), nullable=True),
         sa.Column("aggregation_method", sa.String(length=100), nullable=True),
-        sa.Column("aggregation_in_space", sa.Boolean(), nullable=False),
-        sa.Column("timestep", sa.Integer(), nullable=False),
+        sa.Column("aggregation_in_space", sa.Boolean(), nullable=True),
+        sa.Column("timestep", sa.Integer(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
     )
     create_table_if_not_exists(
         "v2_cross_section_location",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("code", sa.String(length=100), nullable=True),
-        sa.Column("reference_level", sa.Float(), nullable=False),
-        sa.Column("friction_type", sa.Integer(), nullable=False),
-        sa.Column("friction_value", sa.Float(), nullable=False),
+        sa.Column("reference_level", sa.Float(), nullable=True),
+        sa.Column("friction_type", sa.Integer(), nullable=True),
+        sa.Column("friction_value", sa.Float(), nullable=True),
         sa.Column("bank_level", sa.Float(), nullable=True),
         sa.Column(
             "the_geom",
@@ -1081,15 +1074,15 @@ def upgrade():
                 srid=4326,
                 management=True,
             ),
-            nullable=False,
+            nullable=True,
         ),
-        sa.Column("channel_id", sa.Integer(), nullable=False),
-        sa.Column("definition_id", sa.Integer(), nullable=False),
+        sa.Column("channel_id", sa.Integer(), nullable=True),
+        sa.Column("definition_id", sa.Integer(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
     )
     create_table_if_not_exists(
         "v2_windshielding",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=True),
         sa.Column("north", sa.Float(), nullable=True),
         sa.Column("northeast", sa.Float(), nullable=True),
         sa.Column("east", sa.Float(), nullable=True),
@@ -1107,7 +1100,7 @@ def upgrade():
             ),
             nullable=True,
         ),
-        sa.Column("channel_id", sa.Integer(), nullable=False),
+        sa.Column("channel_id", sa.Integer(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
     )
 

--- a/threedi_modelchecker/migrations/versions/0200_initial.py
+++ b/threedi_modelchecker/migrations/versions/0200_initial.py
@@ -375,7 +375,8 @@ def upgrade():
 
     # Initialize the Spatialite if necessary:
     if conn.dialect.name == "sqlite" and "spatial_ref_sys" not in existing_tables:
-        op.execute("SELECT InitSpatialMetadata()")
+        # The (1) performs the init in 1 transaction, which improves performance.
+        op.execute("SELECT InitSpatialMetadata(1)")
 
     version = _get_version(conn)
     if version is not None:

--- a/threedi_modelchecker/migrations/versions/0200_initial.py
+++ b/threedi_modelchecker/migrations/versions/0200_initial.py
@@ -102,7 +102,7 @@ def upgrade_164():
     """
     create_table_if_not_exists(
         "v2_grid_refinement_area",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("display_name", sa.String(length=255), nullable=True),
         sa.Column("refinement_level", sa.Integer(), nullable=True),
         sa.Column("code", sa.String(length=100), nullable=True),
@@ -126,7 +126,7 @@ def upgrade_165():
     """
     create_table_if_not_exists(
         "v2_groundwater",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("groundwater_impervious_layer_level", sa.Float(), nullable=True),
         sa.Column(
             "groundwater_impervious_layer_level_file",
@@ -169,7 +169,7 @@ def upgrade_165():
 
     create_table_if_not_exists(
         "v2_simple_infiltration",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("infiltration_rate", sa.Float(), nullable=True),
         sa.Column("infiltration_rate_file", sa.String(length=255), nullable=True),
         sa.Column("infiltration_surface_option", sa.Integer(), nullable=True),
@@ -180,7 +180,7 @@ def upgrade_165():
 
     create_table_if_not_exists(
         "v2_interflow",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("interflow_type", sa.Integer(), nullable=True),
         sa.Column("porosity", sa.Float(), nullable=True),
         sa.Column("porosity_file", sa.String(length=255), nullable=True),
@@ -378,7 +378,7 @@ def upgrade():
 
     create_table_if_not_exists(
         "v2_2d_boundary_conditions",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("display_name", sa.String(length=255), nullable=True),
         sa.Column("timeseries", sa.Text(), nullable=True),
         sa.Column("boundary_type", sa.Integer(), nullable=True),
@@ -395,7 +395,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_2d_lateral",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("type", sa.Integer(), nullable=True),
         sa.Column(
             "the_geom",
@@ -411,7 +411,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_calculation_point",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("content_type_id", sa.Integer(), nullable=True),
         sa.Column("user_ref", sa.String(length=80), nullable=True),
         sa.Column("calc_type", sa.Integer(), nullable=True),
@@ -428,7 +428,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_connection_nodes",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("storage_area", sa.Float(), nullable=True),
         sa.Column("initial_waterlevel", sa.Float(), nullable=True),
         sa.Column(
@@ -454,7 +454,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_control_delta",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("measure_variable", sa.String(length=50), nullable=True),
         sa.Column("measure_delta", sa.String(length=50), nullable=True),
         sa.Column("measure_dt", sa.Float(), nullable=True),
@@ -467,19 +467,19 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_control_group",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("name", sa.String(length=100), nullable=True),
         sa.Column("description", sa.Text(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
     )
     create_table_if_not_exists(
         "v2_control_measure_group",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.PrimaryKeyConstraint("id"),
     )
     create_table_if_not_exists(
         "v2_control_memory",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("measure_variable", sa.String(length=50), nullable=True),
         sa.Column("upper_threshold", sa.Float(), nullable=True),
         sa.Column("lower_threshold", sa.Float(), nullable=True),
@@ -493,7 +493,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_control_pid",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("measure_variable", sa.String(length=50), nullable=True),
         sa.Column("setpoint", sa.Float(), nullable=True),
         sa.Column("kp", sa.Float(), nullable=True),
@@ -507,7 +507,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_control_table",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("action_table", sa.Text(), nullable=True),
         sa.Column("action_type", sa.String(length=50), nullable=True),
         sa.Column("measure_variable", sa.String(length=50), nullable=True),
@@ -518,7 +518,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_control_timed",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("action_type", sa.String(length=50), nullable=True),
         sa.Column("action_table", sa.Text(), nullable=True),
         sa.Column("target_type", sa.String(length=100), nullable=True),
@@ -527,7 +527,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_cross_section_definition",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("width", sa.String(length=255), nullable=True),
         sa.Column("height", sa.String(length=255), nullable=True),
         sa.Column("shape", sa.Integer(), nullable=True),
@@ -536,7 +536,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_dem_average_area",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column(
             "the_geom",
             geoalchemy2.types.Geometry(
@@ -550,7 +550,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_floodfill",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("waterlevel", sa.Float(), nullable=True),
         sa.Column(
             "the_geom",
@@ -565,7 +565,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_grid_refinement",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("display_name", sa.String(length=255), nullable=True),
         sa.Column("refinement_level", sa.Integer(), nullable=True),
         sa.Column(
@@ -582,7 +582,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_grid_refinement_area",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("display_name", sa.String(length=255), nullable=True),
         sa.Column("refinement_level", sa.Integer(), nullable=True),
         sa.Column("code", sa.String(length=100), nullable=True),
@@ -599,7 +599,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_groundwater",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("groundwater_impervious_layer_level", sa.Float(), nullable=True),
         sa.Column(
             "groundwater_impervious_layer_level_file",
@@ -641,7 +641,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_impervious_surface",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("code", sa.String(length=100), nullable=True),
         sa.Column("display_name", sa.String(length=255), nullable=True),
         sa.Column("surface_inclination", sa.String(length=64), nullable=True),
@@ -664,7 +664,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_interflow",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("interflow_type", sa.Integer(), nullable=True),
         sa.Column("porosity", sa.Float(), nullable=True),
         sa.Column("porosity_file", sa.String(length=255), nullable=True),
@@ -677,7 +677,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_levee",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("code", sa.String(length=100), nullable=True),
         sa.Column("crest_level", sa.Float(), nullable=True),
         sa.Column(
@@ -695,7 +695,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_numerical_settings",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("cfl_strictness_factor_1d", sa.Float(), nullable=True),
         sa.Column("cfl_strictness_factor_2d", sa.Float(), nullable=True),
         sa.Column("convergence_cg", sa.Float(), nullable=True),
@@ -722,7 +722,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_obstacle",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("code", sa.String(length=100), nullable=True),
         sa.Column("crest_level", sa.Float(), nullable=True),
         sa.Column(
@@ -738,7 +738,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_simple_infiltration",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("infiltration_rate", sa.Float(), nullable=True),
         sa.Column("infiltration_rate_file", sa.String(length=255), nullable=True),
         sa.Column("infiltration_surface_option", sa.Integer(), nullable=True),
@@ -748,7 +748,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_surface_parameters",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("outflow_delay", sa.Float(), nullable=True),
         sa.Column("surface_layer_thickness", sa.Float(), nullable=True),
         sa.Column("infiltration", sa.Boolean(), nullable=True),
@@ -760,23 +760,22 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_1d_boundary_conditions",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("boundary_type", sa.Integer(), nullable=True),
         sa.Column("timeseries", sa.Text(), nullable=True),
         sa.Column("connection_node_id", sa.Integer(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("connection_node_id"),
     )
     create_table_if_not_exists(
         "v2_1d_lateral",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("connection_node_id", sa.Integer(), nullable=True),
         sa.Column("timeseries", sa.Text(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
     )
     create_table_if_not_exists(
         "v2_channel",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("display_name", sa.String(length=255), nullable=True),
         sa.Column("code", sa.String(length=100), nullable=True),
         sa.Column("calculation_type", sa.Integer(), nullable=True),
@@ -797,7 +796,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_connected_pnt",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("calculation_pnt_id", sa.Integer(), nullable=True),
         sa.Column("levee_id", sa.Integer(), nullable=True),
         sa.Column("exchange_level", sa.Float(), nullable=True),
@@ -814,7 +813,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_control",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("control_group_id", sa.Integer(), nullable=True),
         sa.Column("measure_group_id", sa.Integer(), nullable=True),
         sa.Column("control_type", sa.String(length=15), nullable=True),
@@ -826,7 +825,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_control_measure_map",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("measure_group_id", sa.Integer(), nullable=True),
         sa.Column("object_type", sa.String(length=100), nullable=True),
         sa.Column("object_id", sa.Integer(), nullable=True),
@@ -835,7 +834,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_culvert",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("display_name", sa.String(length=255), nullable=True),
         sa.Column("code", sa.String(length=100), nullable=True),
         sa.Column("calculation_type", sa.Integer(), nullable=True),
@@ -863,7 +862,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_global_settings",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("use_2d_flow", sa.Boolean(), nullable=True),
         sa.Column("use_1d_flow", sa.Boolean(), nullable=True),
         sa.Column("manhole_storage_area", sa.Float(), nullable=True),
@@ -918,7 +917,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_impervious_surface_map",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("percentage", sa.Float(), nullable=True),
         sa.Column("impervious_surface_id", sa.Integer(), nullable=True),
         sa.Column("connection_node_id", sa.Integer(), nullable=True),
@@ -926,7 +925,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_manhole",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("display_name", sa.String(length=255), nullable=True),
         sa.Column("code", sa.String(length=100), nullable=True),
         sa.Column("zoom_category", sa.Integer(), nullable=True),
@@ -944,7 +943,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_orifice",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("code", sa.String(length=100), nullable=True),
         sa.Column("display_name", sa.String(length=255), nullable=True),
         sa.Column("zoom_category", sa.Integer(), nullable=True),
@@ -962,7 +961,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_pipe",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("display_name", sa.String(length=255), nullable=True),
         sa.Column("code", sa.String(length=100), nullable=True),
         sa.Column("profile_num", sa.Integer(), nullable=True),
@@ -983,7 +982,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_pumpstation",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("code", sa.String(length=100), nullable=True),
         sa.Column("display_name", sa.String(length=255), nullable=True),
         sa.Column("zoom_category", sa.Integer(), nullable=True),
@@ -1000,7 +999,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_surface",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("display_name", sa.String(length=255), nullable=True),
         sa.Column("code", sa.String(length=100), nullable=True),
         sa.Column("zoom_category", sa.Integer(), nullable=True),
@@ -1022,7 +1021,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_surface_map",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("surface_type", sa.String(length=40), nullable=True),
         sa.Column("surface_id", sa.Integer(), nullable=True),
         sa.Column("connection_node_id", sa.Integer(), nullable=True),
@@ -1031,7 +1030,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_weir",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("code", sa.String(length=100), nullable=True),
         sa.Column("display_name", sa.String(length=255), nullable=True),
         sa.Column("crest_level", sa.Float(), nullable=True),
@@ -1050,7 +1049,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_aggregation_settings",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("global_settings_id", sa.Integer(), nullable=True),
         sa.Column("var_name", sa.String(length=100), nullable=True),
         sa.Column("flow_variable", sa.String(length=100), nullable=True),
@@ -1061,7 +1060,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_cross_section_location",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("code", sa.String(length=100), nullable=True),
         sa.Column("reference_level", sa.Float(), nullable=True),
         sa.Column("friction_type", sa.Integer(), nullable=True),
@@ -1082,7 +1081,7 @@ def upgrade():
     )
     create_table_if_not_exists(
         "v2_windshielding",
-        sa.Column("id", sa.Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("north", sa.Float(), nullable=True),
         sa.Column("northeast", sa.Float(), nullable=True),
         sa.Column("east", sa.Float(), nullable=True),

--- a/threedi_modelchecker/migrations/versions/0207_fix_schema_constraints.py
+++ b/threedi_modelchecker/migrations/versions/0207_fix_schema_constraints.py
@@ -6,11 +6,13 @@ Create Date: 2022-05-18 10:15:20.851968
 
 """
 from alembic import op
+
 import sqlalchemy as sa
 
+
 # revision identifiers, used by Alembic.
-revision = '0207'
-down_revision = '0206'
+revision = "0207"
+down_revision = "0206"
 branch_labels = None
 depends_on = None
 

--- a/threedi_modelchecker/spatialite_versions.py
+++ b/threedi_modelchecker/spatialite_versions.py
@@ -1,8 +1,9 @@
-from sqlalchemy import inspect
+from .threedi_model import models
 from geoalchemy2 import func as geo_func
 from geoalchemy2.types import Geometry
-from .threedi_model import models
-from sqlalchemy.exc import IntegrityError, OperationalError
+from sqlalchemy import inspect
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import OperationalError
 from threedi_modelchecker.errors import UpgradeFailedError
 
 


### PR DESCRIPTION
I removed the "quick" creation of the db schema for empty databases (also for the 3->4 upgrade). In that way I had no control over the constraints. See issue comment. on #187 

I kept the "PrimaryKey" constraints (including NOT NULL on id) because having no primary key broke all my tests. I don't know how to set this up with the server-side id sequence and without the NOT NULL. I hope that is OK.