### PR TITLE
Check that refinement_level is not greater than kmax

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Changelog of threedi-modelchecker
 
 - Removed PostGIS support.
 
+- Check that refinement_level is not greater than kmax (E0800).
+
 
 0.28 (2022-09-20)
 -----------------

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -60,6 +60,11 @@ CONDITIONS = {
     ),
 }
 
+try:
+    kmax = Query(models.GlobalSetting.kmax).limit(1).scalar_subquery()
+except AttributeError:
+    kmax = Query(models.GlobalSetting.kmax).limit(1).as_scalar()
+
 CHECKS: List[BaseCheck] = []
 
 ## 002x: FRICTION
@@ -1154,6 +1159,16 @@ CHECKS += [
     ),
 ]
 
+## 080x: refinement levels
+CHECKS += [
+    QueryCheck(
+        error_code=800,
+        column=model.refinement_level,
+        invalid=Query(model).filter(model.refinement_level > kmax),
+        message=f"{model.__table__.name}.refinement_level must not be greater than v2_global_settings.kmax",
+    )
+    for model in (models.GridRefinement, models.GridRefinementArea)
+]
 
 ## 110x: SIMULATION SETTINGS, timestep
 CHECKS += [


### PR DESCRIPTION
Tested with "meerssen_t25.sqlite". Got a lot of errors (also from #207 ).