### PR TITLE
Disable raster checkers for GDAL < 3.4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@ Changelog of threedi-modelchecker
 =================================
 
 
+0.32.1 (unreleased)
+-------------------
+
+- Disable checking rasters over HTTP when using GDAL < 3.4.
+
+
 0.32 (2022-11-16)
 -----------------
 


### PR DESCRIPTION
The problem is that we need GDAL 3.4 to read rasters directly from the object store.

On our backend we don't have that, and it is not easy to upgrade it there.

So as a temporary fix, I disabled the raster checks if you are using HTTP(S) and if GDAL < 3.4.

Real solutions include:
- use GDAL >3.4 on the backend
- implement an interface using rasterio