### PR TITLE
fix console script path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     python_requires=">=3.7",
     entry_points={
         "console_scripts": [
-            "threedi_modelchecker = threedi_modelchecker.scripts:threedi_modelchecker"
+            "threedi_modelchecker = threedi_modelchecker.scripts:main"
         ]
     },
 )


### PR DESCRIPTION
Currently, when running threedi_modelchecker in the console, an error is thrown:
`ImportError: cannot import name 'threedi_modelchecker' from 'threedi_modelchecker.scripts'`
because the function being imported has been renamed to `main`. This commit fixes the issue by updating the import name.