### PR TITLE
244 confirm that crest level of weir orifice is higher than bottom level of manhole

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog of threedi-modelchecker
 1.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add warning 108: the crest_level of a weir or orifice cannot be lower than
+  the bottom_level of any manhole it is connected to.
 
 
 1.0.1 (2023-02-02)

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -587,7 +587,8 @@ CHECKS += [
         invalid=Query(table)
         .join(
             models.ConnectionNode,
-            table.connection_node_start_id == models.ConnectionNode.id or table.connection_node_end_id == models.ConnectionNode.id,
+            table.connection_node_start_id == models.ConnectionNode.id
+            or table.connection_node_end_id == models.ConnectionNode.id,
         )
         .join(models.Manhole)
         .filter(

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -579,6 +579,24 @@ CHECKS += [
         message="v2_manhole.drain_level cannot be null when using sub-basins (v2_global_settings.manhole_storage_area > 0) and no DEM is supplied.",
     ),
 ]
+CHECKS += [
+    QueryCheck(
+        level=CheckLevel.WARNING,
+        error_code=108,
+        column=table.crest_level,
+        invalid=Query(table)
+        .join(
+            models.ConnectionNode,
+            table.connection_node_start_id == models.ConnectionNode.id,
+        )
+        .join(models.Manhole)
+        .filter(
+            table.crest_level < models.Manhole.bottom_level,
+        ),
+        message=f"{table.__tablename__}.crest_level should be higher than or equal to v2_manhole.bottom_level.",
+    )
+    for table in [models.Weir, models.Orifice]
+]
 
 ## 020x: Spatial checks
 

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -587,13 +587,13 @@ CHECKS += [
         invalid=Query(table)
         .join(
             models.ConnectionNode,
-            table.connection_node_start_id == models.ConnectionNode.id,
+            table.connection_node_start_id == models.ConnectionNode.id or table.connection_node_end_id == models.ConnectionNode.id,
         )
         .join(models.Manhole)
         .filter(
             table.crest_level < models.Manhole.bottom_level,
         ),
-        message=f"{table.__tablename__}.crest_level should be higher than or equal to v2_manhole.bottom_level.",
+        message=f"{table.__tablename__}.crest_level should be higher than or equal to v2_manhole.bottom_level for all the connected manholes.",
     )
     for table in [models.Weir, models.Orifice]
 ]

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -587,8 +587,8 @@ CHECKS += [
         invalid=Query(table)
         .join(
             models.ConnectionNode,
-            table.connection_node_start_id == models.ConnectionNode.id
-            or table.connection_node_end_id == models.ConnectionNode.id,
+            (table.connection_node_start_id == models.ConnectionNode.id)
+            | (table.connection_node_end_id == models.ConnectionNode.id),
         )
         .join(models.Manhole)
         .filter(


### PR DESCRIPTION
This PR adds a level check to ensure that the crest level of a weir or orifice is higher than or equal to the bottom level of the manholes it is connected to.