### PR TITLE
271 channel manhole level check

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@ Changelog of threedi-modelchecker
 
 - Add warning 108: the crest_level of a weir or orifice cannot be lower than
   the bottom_level of any manhole it is connected to.
+- Add info 109 and 110: the bottom level of a manhole cannot be higher than
+  the reference level of the closest cross-section of any channel it is
+  connected to. threedigrid-builder automatically fixes this, hence info
+  instead of warning.
 
 
 1.0.1 (2023-02-02)
@@ -87,6 +91,8 @@ Changelog of threedi-modelchecker
 
 - The ThreediModelChecker context now accepts a "context_type" and "raster_interface"
   fields.
+
+- Python 3.7 support is dropped.
 
 
 0.32 (2022-11-16)

--- a/threedi_modelchecker/checks/other.py
+++ b/threedi_modelchecker/checks/other.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, NamedTuple, Literal
+from typing import List, Literal, NamedTuple
 
 from sqlalchemy import func, text
 from sqlalchemy.orm import aliased, Query, Session

--- a/threedi_modelchecker/checks/other.py
+++ b/threedi_modelchecker/checks/other.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, NamedTuple
+from typing import List, NamedTuple, Literal
 
 from sqlalchemy import func, text
 from sqlalchemy.orm import aliased, Query, Session
@@ -190,7 +190,7 @@ class ChannelManholeLevelCheck(BaseCheck):
     def __init__(
         self,
         level: CheckLevel = CheckLevel.INFO,
-        nodes_to_check: str = "start",
+        nodes_to_check: Literal["start", "end"] = "start",
         *args,
         **kwargs,
     ):

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -40,6 +40,7 @@ from .checks.factories import (
 )
 from .checks.other import (
     BoundaryCondition1DObjectNumberCheck,
+    ChannelManholeLevelCheck,
     ConnectionNodesDistance,
     ConnectionNodesLength,
     CrossSectionLocationCheck,
@@ -597,6 +598,14 @@ CHECKS += [
         message=f"{table.__tablename__}.crest_level should be higher than or equal to v2_manhole.bottom_level for all the connected manholes.",
     )
     for table in [models.Weir, models.Orifice]
+]
+CHECKS += [
+    ChannelManholeLevelCheck(
+        level=CheckLevel.INFO, nodes_to_check="start", error_code=108
+    ),
+    ChannelManholeLevelCheck(
+        level=CheckLevel.INFO, nodes_to_check="end", error_code=109
+    ),
 ]
 
 ## 020x: Spatial checks

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -601,10 +601,10 @@ CHECKS += [
 ]
 CHECKS += [
     ChannelManholeLevelCheck(
-        level=CheckLevel.INFO, nodes_to_check="start", error_code=108
+        level=CheckLevel.INFO, nodes_to_check="start", error_code=109
     ),
     ChannelManholeLevelCheck(
-        level=CheckLevel.INFO, nodes_to_check="end", error_code=109
+        level=CheckLevel.INFO, nodes_to_check="end", error_code=110
     ),
 ]
 

--- a/threedi_modelchecker/tests/test_checks_other.py
+++ b/threedi_modelchecker/tests/test_checks_other.py
@@ -8,6 +8,7 @@ from threedi_modelchecker.checks.other import (
     ConnectionNodesLength,
     CrossSectionLocationCheck,
     LinestringLocationCheck,
+    ChannelManholeLevelCheck,
     OpenChannelsWithNestedNewton,
     PotentialBreachInterdistanceCheck,
     PotentialBreachStartEndCheck,
@@ -132,6 +133,52 @@ def test_open_channels_with_nested_newton(session):
 
     errors = check.get_invalid(session)
     assert len(errors) == 2
+
+
+channel_manhole_level_testdata = [
+    ("start", -1, -3, -2, 0),
+    ("start", -3, -1, -2, 1),
+    ("end", -3, -1, -2, 0),
+    ("end", -1, -3, -2, 1),
+]
+@pytest.mark.parametrize("manhole_location,starting_reference_level,ending_reference_level,manhole_level,errors_number", channel_manhole_level_testdata)
+def test_channel_manhole_level_check(session, manhole_location, starting_reference_level, ending_reference_level, manhole_level, errors_number):
+    # using factories, create one minimal test case which passes, and one which fails
+    # once that works, parametrise.
+    # use nested factories for channel and connectionNode
+    starting_coordinates = "4.718300 52.696686"
+    ending_coordinates = "4.718255 52.696709"
+    start_node = factories.ConnectionNodeFactory(
+        the_geom=f"SRID=4326;POINT({starting_coordinates})"
+    )
+    end_node = factories.ConnectionNodeFactory(
+        the_geom=f"SRID=4326;POINT({ending_coordinates})"
+    )
+    channel = factories.ChannelFactory(
+        the_geom=f"SRID=4326;LINESTRING({starting_coordinates}, {ending_coordinates})",
+        connection_node_start=start_node,
+        connection_node_end=end_node
+    )
+    # starting cross-section location
+    factories.CrossSectionLocationFactory(
+        the_geom="SRID=4326;POINT(4.718278 52.696697)",
+        reference_level=starting_reference_level,
+        channel=channel
+    )
+    # ending cross-section location
+    factories.CrossSectionLocationFactory(
+        the_geom="SRID=4326;POINT(4.718264 52.696704)",
+        reference_level=ending_reference_level,
+        channel=channel
+    )
+    # manhole
+    factories.ManholeFactory(
+        connection_node=end_node if manhole_location == "end" else start_node,
+        bottom_level=manhole_level
+    )
+    check=ChannelManholeLevelCheck(nodes_to_check=manhole_location)
+    errors = check.get_invalid(session)
+    assert len(errors) == errors_number
 
 
 def test_node_distance(session):


### PR DESCRIPTION
Add check to confirm that the bottom_level of a manhole is higher than the reference_level of the closest cross-section on a connected channel. Since this issue will be fixed anyway in threedigrid-builder, the message level of this check is INFO, not WARNING; no further user action is required.