### PR TITLE
279 make cli generate check summary for docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,16 @@ Changelog of threedi-modelchecker
   the reference level of the closest cross-section of any channel it is
   connected to. threedigrid-builder automatically fixes this, hence info
   instead of warning.
+- Rewrite command-line client. The `--sqlite` argument is now an argument of the
+  `check` command, not of the main `threedi_modelchecker` group. To run a check,
+  the new syntax is 
+  `threedi_modelchecker check -s <your database>.sqlite -l <desired check level>`
+  Run `threedi_modelcheck check --help` for an overview.
+
+  A new command, `export-checks`, has also been added. This exports all checks
+  executed by the model checker as an RsT table or in CSV format, as specified by
+  the optional `--format` argument. The check output can also be dumped to a file
+  using `--file`. Run `threedi_modelcheck export-checks --help` for an overview.
 
 
 1.0.1 (2023-02-02)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,14 +17,14 @@ Changelog of threedi-modelchecker
 
   ``threedi_modelchecker check -s <your database>.sqlite -l <desired check level>``
 
-  Run ``threedi_modelcheck check --help`` for an overview.
+  Run ``threedi_modelchecker check --help`` for an overview.
 
   A new command, ``export-checks``, has also been added. This exports all checks
   executed by the model checker as an RsT table or in CSV format, as specified by
   the optional ``--format`` argument. The check output can also be dumped to a file
   using ``--file``.
   
-  Run ``threedi_modelcheck export-checks --help`` for an overview.
+  Run ``threedi_modelchecker export-checks --help`` for an overview.
 
 
 1.0.1 (2023-02-02)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,14 +13,18 @@ Changelog of threedi-modelchecker
   instead of warning.
 - Rewrite command-line client. The `--sqlite` argument is now an argument of the
   `check` command, not of the main `threedi_modelchecker` group. To run a check,
-  the new syntax is 
+  the new syntax is
+
   `threedi_modelchecker check -s <your database>.sqlite -l <desired check level>`
+
   Run `threedi_modelcheck check --help` for an overview.
 
   A new command, `export-checks`, has also been added. This exports all checks
   executed by the model checker as an RsT table or in CSV format, as specified by
   the optional `--format` argument. The check output can also be dumped to a file
-  using `--file`. Run `threedi_modelcheck export-checks --help` for an overview.
+  using `--file`.
+  
+  Run `threedi_modelcheck export-checks --help` for an overview.
 
 
 1.0.1 (2023-02-02)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,20 +11,21 @@ Changelog of threedi-modelchecker
   the reference level of the closest cross-section of any channel it is
   connected to. threedigrid-builder automatically fixes this, hence info
   instead of warning.
-- Rewrite command-line client. The `--sqlite` argument is now an argument of the
-  `check` command, not of the main `threedi_modelchecker` group. To run a check,
+- Rewrite command-line client. The ``--sqlite`` argument is now an argument of the
+  ``check`` command, not of the main ``threedi_modelchecker`` group. To run a check,
   the new syntax is
 
-  `threedi_modelchecker check -s <your database>.sqlite -l <desired check level>`
+  .. code-block:: bash
+     threedi_modelchecker check -s <your database>.sqlite -l <desired check level>
 
-  Run `threedi_modelcheck check --help` for an overview.
+  Run ``threedi_modelcheck check --help`` for an overview.
 
-  A new command, `export-checks`, has also been added. This exports all checks
+  A new command, ``export-checks``, has also been added. This exports all checks
   executed by the model checker as an RsT table or in CSV format, as specified by
-  the optional `--format` argument. The check output can also be dumped to a file
-  using `--file`.
+  the optional ``--format`` argument. The check output can also be dumped to a file
+  using ``--file``.
   
-  Run `threedi_modelcheck export-checks --help` for an overview.
+  Run ``threedi_modelcheck export-checks --help`` for an overview.
 
 
 1.0.1 (2023-02-02)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,14 +18,9 @@ Changelog of threedi-modelchecker
 
   ``threedi_modelchecker check -s <your database>.sqlite -l <desired check level>``
 
-  Run ``threedi_modelchecker check --help`` for an overview.
-
-  A new command, ``export-checks``, has also been added. This exports all checks
-  executed by the model checker as an RsT table or in CSV format, as specified by
-  the optional ``--format`` argument. The check output can also be dumped to a file
-  using ``--file``.
-  
-  Run ``threedi_modelchecker export-checks --help`` for an overview.
+- Add new command, ``export-checks``. This exports all checks executed by the model
+  checker as an RsT table or in CSV format, as specified by the optional ``--format``
+  argument. The check output can also be dumped to a file using ``--file``.
 
 - Compatibility fix with rasterio 1.3.6.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,8 +15,7 @@ Changelog of threedi-modelchecker
   ``check`` command, not of the main ``threedi_modelchecker`` group. To run a check,
   the new syntax is
 
-  .. code-block:: bash
-     threedi_modelchecker check -s <your database>.sqlite -l <desired check level>
+  ``threedi_modelchecker check -s <your database>.sqlite -l <desired check level>``
 
   Run ``threedi_modelcheck check --help`` for an overview.
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     tests_require=tests_require,
     extras_require={
         "test": tests_require,
-        "rasterio": ["rasterio>=1.3"],
+        "rasterio": ["rasterio>=1.3,<1.3.6"],
     },
     python_requires=">=3.7",
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     python_requires=">=3.7",
     entry_points={
         "console_scripts": [
-            "threedi_modelchecker = threedi_modelchecker.scripts:main"
+            "threedi_modelchecker = threedi_modelchecker.scripts:cli"
         ]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     tests_require=tests_require,
     extras_require={
         "test": tests_require,
-        "rasterio": ["rasterio>=1.3,<1.3.6"],
+        "rasterio": ["rasterio>=1.3"],
     },
     python_requires=">=3.7",
     entry_points={

--- a/threedi_modelchecker/exporters.py
+++ b/threedi_modelchecker/exporters.py
@@ -1,8 +1,11 @@
+import csv
+from io import StringIO
 from typing import NamedTuple
 
 from threedi_modelchecker.checks.base import BaseCheck
 
 
+# error handling export functions
 def print_errors(errors):
     """Simply prints all errors to stdout
 
@@ -35,3 +38,50 @@ def format_check_results(check: BaseCheck, invalid_row: NamedTuple):
         row_id=invalid_row.id,
         description=check.description(),
     )
+
+# check overview export functions
+def generate_rst_table(checks) -> str:
+    "Generate an RST table to copy into the Sphinx docs with a list of checks"
+    rst_table_string = ""
+    header = (
+        ".. list-table:: Executed checks\n"
+        + "   :widths: 10 20 40\n"
+        + "   :header-rows: 1\n\n"
+        + "   * - Check number\n"
+        + "     - Check level\n"
+        + "     - Check message"
+    )
+    rst_table_string += header
+    for check in checks:
+        # pad error code with leading zeroes so it is always 4 numbers
+        formatted_error_code = str(check.error_code).zfill(4)
+        check_row = (
+            "\n"
+            + f"   * - {formatted_error_code}\n"
+            + f"     - {check.level.name.capitalize()}\n"
+            + f"     - {check.description()}"
+        )
+        rst_table_string += check_row
+    return rst_table_string
+
+def generate_csv_table(checks) -> str:
+    "Generate an CSV table with a list of checks for use elsewhere"
+    # a StringIO buffer is used so that the CSV can be printed to terminal as well as written to file
+    output_buffer = StringIO()
+    fieldnames = ["error_code", "level", "description"]
+    writer = csv.DictWriter(
+        output_buffer, fieldnames=fieldnames, quoting=csv.QUOTE_NONNUMERIC
+    )
+
+    writer.writeheader()
+
+    for check in checks:
+        writer.writerow(
+            {
+                "error_code": check.error_code,
+                "level": check.level.name,
+                "description": check.description(),
+            }
+        )
+
+    return output_buffer.getvalue()

--- a/threedi_modelchecker/exporters.py
+++ b/threedi_modelchecker/exporters.py
@@ -39,6 +39,7 @@ def format_check_results(check: BaseCheck, invalid_row: NamedTuple):
         description=check.description(),
     )
 
+
 # check overview export functions
 def generate_rst_table(checks) -> str:
     "Generate an RST table to copy into the Sphinx docs with a list of checks"
@@ -63,6 +64,7 @@ def generate_rst_table(checks) -> str:
         )
         rst_table_string += check_row
     return rst_table_string
+
 
 def generate_csv_table(checks) -> str:
     "Generate an CSV table with a list of checks for use elsewhere"

--- a/threedi_modelchecker/scripts.py
+++ b/threedi_modelchecker/scripts.py
@@ -25,8 +25,7 @@ def cli():
     help="Path to an sqlite (spatialite) file",
     required=True,
 )
-@click.pass_context
-def check(ctx, sqlite, file, level):
+def check(sqlite, file, level):
     """Checks the threedi-model for errors / warnings / info messages"""
     db = ThreediDatabase(sqlite, echo=False)
     """Checks the threedi model schematisation for errors."""
@@ -52,8 +51,7 @@ def check(ctx, sqlite, file, level):
     click.echo("Finished processing model")
 
 @cli.command()
-@click.pass_context
-def export_checks(ctx):
+def export_checks():
     "Export formatted checks summary to insert in documentation"
     click.echo("in progress")
 

--- a/threedi_modelchecker/scripts.py
+++ b/threedi_modelchecker/scripts.py
@@ -7,23 +7,9 @@ from threedi_modelchecker.model_checks import ThreediModelChecker
 
 
 @click.group()
-@click.option(
-    "-s",
-    "--sqlite",
-    type=click.Path(exists=True, readable=True),
-    help="Path to an sqlite (spatialite) file",
-    required=True,
-)
-@click.pass_context
-def main(ctx, sqlite):
-    """Checks the threedi-model for errors / warnings / info messages"""
-    ctx.ensure_object(dict)
-
-    db = ThreediDatabase(sqlite, echo=False)
-    ctx.obj["db"] = db
-
-
-@main.command()
+def cli():
+    pass
+@cli.command()
 @click.option("-f", "--file", help="Write errors to file, instead of stdout")
 @click.option(
     "-l",
@@ -32,8 +18,17 @@ def main(ctx, sqlite):
     default="ERROR",
     help="Minimum check level.",
 )
+@click.option(
+    "-s",
+    "--sqlite",
+    type=click.Path(exists=True, readable=True),
+    help="Path to an sqlite (spatialite) file",
+    required=True,
+)
 @click.pass_context
-def check(ctx, file, level):
+def check(ctx, sqlite, file, level):
+    """Checks the threedi-model for errors / warnings / info messages"""
+    db = ThreediDatabase(sqlite, echo=False)
     """Checks the threedi model schematisation for errors."""
     level = level.upper()
     if level == "ERROR":
@@ -46,7 +41,7 @@ def check(ctx, file, level):
     if file:
         click.echo("Model errors will be written to %s" % file)
 
-    mc = ThreediModelChecker(ctx.obj["db"])
+    mc = ThreediModelChecker(db)
     model_errors = mc.errors(level=level)
 
     if file:
@@ -56,6 +51,12 @@ def check(ctx, file, level):
 
     click.echo("Finished processing model")
 
+@cli.command()
+@click.pass_context
+def export_checks(ctx):
+    "Export formatted checks summary to insert in documentation"
+    click.echo("in progress")
+
 
 if __name__ == "__main__":
-    main()
+    check()

--- a/threedi_modelchecker/scripts.py
+++ b/threedi_modelchecker/scripts.py
@@ -1,6 +1,3 @@
-import csv
-from io import StringIO
-
 import click
 from threedi_schema import ThreediDatabase
 from threedi_schema.domain.models import DECLARED_MODELS
@@ -69,59 +66,12 @@ def check(sqlite, file, level):
 )
 def export_checks(file, format):
     """Export formatted checks summary to insert in documentation or use elsewhere"""
-
-    def generate_rst_table(checks) -> str:
-        "Generate an RST table to copy into the Sphinx docs with a list of checks"
-        rst_table_string = ""
-        header = (
-            ".. list-table:: Executed checks\n"
-            + "   :widths: 10 20 40\n"
-            + "   :header-rows: 1\n\n"
-            + "   * - Check number\n"
-            + "     - Check level\n"
-            + "     - Check message"
-        )
-        rst_table_string += header
-        for check in checks:
-            # pad error code with leading zeroes so it is always 4 numbers
-            formatted_error_code = str(check.error_code).zfill(4)
-            check_row = (
-                "\n"
-                + f"   * - {formatted_error_code}\n"
-                + f"     - {check.level.name.capitalize()}\n"
-                + f"     - {check.description()}"
-            )
-            rst_table_string += check_row
-        return rst_table_string
-
-    def generate_csv_table(checks) -> str:
-        "Generate an CSV table with a list of checks for use elsewhere"
-        # a StringIO buffer is used so that the CSV can be printed to terminal as well as written to file
-        output_buffer = StringIO()
-        fieldnames = ["error_code", "level", "description"]
-        writer = csv.DictWriter(
-            output_buffer, fieldnames=fieldnames, quoting=csv.QUOTE_NONNUMERIC
-        )
-
-        writer.writeheader()
-
-        for check in checks:
-            writer.writerow(
-                {
-                    "error_code": check.error_code,
-                    "level": check.level.name,
-                    "description": check.description(),
-                }
-            )
-
-        return output_buffer.getvalue()
-
     checks = Config(models=DECLARED_MODELS).checks
 
     if format.lower() == "rst":
-        table = generate_rst_table(checks=checks)
+        table = exporters.generate_rst_table(checks=checks)
     elif format.lower() == "csv":
-        table = generate_csv_table(checks=checks)
+        table = exporters.generate_csv_table(checks=checks)
     if file:
         with open(file, "w") as f:
             f.write(table)

--- a/threedi_modelchecker/scripts.py
+++ b/threedi_modelchecker/scripts.py
@@ -1,9 +1,12 @@
 import click
 from threedi_schema import ThreediDatabase
+from threedi_schema.domain.models import DECLARED_MODELS
 
 from threedi_modelchecker import exporters
 from threedi_modelchecker.checks.base import CheckLevel
 from threedi_modelchecker.model_checks import ThreediModelChecker
+from threedi_modelchecker.config import Config
+from threedi_modelchecker.checks.base import CheckLevel
 
 
 @click.group()
@@ -52,9 +55,18 @@ def check(sqlite, file, level):
 
 @cli.command()
 def export_checks():
-    "Export formatted checks summary to insert in documentation"
-    click.echo("in progress")
-
+    """Export formatted checks summary to insert in documentation"""
+    checks = Config(models=DECLARED_MODELS).checks
+    info_checks = []
+    warning_checks = []
+    error_checks = []
+    for check in checks:
+        if check.level == CheckLevel.INFO:
+            info_checks.append(check)
+        elif check.level == CheckLevel.WARNING:
+            warning_checks.append(check)
+        elif check.level == CheckLevel.ERROR:
+            error_checks.append(check)
 
 if __name__ == "__main__":
     check()

--- a/threedi_modelchecker/tests/test_exporters.py
+++ b/threedi_modelchecker/tests/test_exporters.py
@@ -1,0 +1,42 @@
+import pytest
+from threedi_modelchecker.checks.base import CheckLevel
+
+from threedi_modelchecker.exporters import (
+    generate_rst_table, generate_csv_table
+)
+
+@pytest.fixture
+def fake_checks():
+    class FakeCheck:
+        def __init__(self, level, error_code):
+            self.level = level
+            self.error_code = error_code
+        
+        def description(self):
+            return f"This sample message has code {self.error_code} and level {self.level.name}"
+
+    fake_checks = [
+        FakeCheck(level=CheckLevel.WARNING, error_code=2),
+        FakeCheck(level=CheckLevel.ERROR, error_code=1234),
+        FakeCheck(level=CheckLevel.INFO, error_code=12),
+        ]
+    
+    return fake_checks
+
+def test_generate_rst_table(fake_checks):
+    correct_rst_result = (".. list-table:: Executed checks\n" +
+                          "   :widths: 10 20 40\n   :header-rows: 1\n\n" +
+                          "   * - Check number\n" +
+                          "     - Check level\n" +
+                          "     - Check message\n" +
+                          "   * - 0002\n" +
+                          "     - Warning\n" +
+                          "     - This sample message has code 2 and level WARNING\n" +
+                          "   * - 1234\n" +
+                          "     - Error\n" +
+                          "     - This sample message has code 1234 and level ERROR\n" +
+                          "   * - 0012\n" +
+                          "     - Info\n" +
+                          "     - This sample message has code 12 and level INFO")
+    rst_result = generate_rst_table(fake_checks)
+    assert rst_result == correct_rst_result

--- a/threedi_modelchecker/tests/test_exporters.py
+++ b/threedi_modelchecker/tests/test_exporters.py
@@ -1,9 +1,8 @@
 import pytest
-from threedi_modelchecker.checks.base import CheckLevel
 
-from threedi_modelchecker.exporters import (
-    generate_rst_table, generate_csv_table
-)
+from threedi_modelchecker.checks.base import CheckLevel
+from threedi_modelchecker.exporters import generate_csv_table, generate_rst_table
+
 
 @pytest.fixture
 def fake_checks():
@@ -11,7 +10,7 @@ def fake_checks():
         def __init__(self, level, error_code):
             self.level = level
             self.error_code = error_code
-        
+
         def description(self):
             return f"This sample message has code {self.error_code} and level {self.level.name}"
 
@@ -19,24 +18,38 @@ def fake_checks():
         FakeCheck(level=CheckLevel.WARNING, error_code=2),
         FakeCheck(level=CheckLevel.ERROR, error_code=1234),
         FakeCheck(level=CheckLevel.INFO, error_code=12),
-        ]
-    
+    ]
+
     return fake_checks
 
+
 def test_generate_rst_table(fake_checks):
-    correct_rst_result = (".. list-table:: Executed checks\n" +
-                          "   :widths: 10 20 40\n   :header-rows: 1\n\n" +
-                          "   * - Check number\n" +
-                          "     - Check level\n" +
-                          "     - Check message\n" +
-                          "   * - 0002\n" +
-                          "     - Warning\n" +
-                          "     - This sample message has code 2 and level WARNING\n" +
-                          "   * - 1234\n" +
-                          "     - Error\n" +
-                          "     - This sample message has code 1234 and level ERROR\n" +
-                          "   * - 0012\n" +
-                          "     - Info\n" +
-                          "     - This sample message has code 12 and level INFO")
+    correct_rst_result = (
+        ".. list-table:: Executed checks\n"
+        + "   :widths: 10 20 40\n   :header-rows: 1\n\n"
+        + "   * - Check number\n"
+        + "     - Check level\n"
+        + "     - Check message\n"
+        + "   * - 0002\n"
+        + "     - Warning\n"
+        + "     - This sample message has code 2 and level WARNING\n"
+        + "   * - 1234\n"
+        + "     - Error\n"
+        + "     - This sample message has code 1234 and level ERROR\n"
+        + "   * - 0012\n"
+        + "     - Info\n"
+        + "     - This sample message has code 12 and level INFO"
+    )
     rst_result = generate_rst_table(fake_checks)
     assert rst_result == correct_rst_result
+
+
+def test_generate_csv_table(fake_checks):
+    correct_csv_result = (
+        '"error_code","level","description"\r\n'
+        + '2,"WARNING","This sample message has code 2 and level WARNING"\r\n'
+        + '1234,"ERROR","This sample message has code 1234 and level ERROR"\r\n'
+        + '12,"INFO","This sample message has code 12 and level INFO"\r\n'
+    )
+    csv_result = generate_csv_table(fake_checks)
+    assert csv_result == correct_csv_result


### PR DESCRIPTION
This PR adds a command to export a list of all checks run by the model checker, either as an RsT table or in CSV format. The output can be written to stdout or dumped to a file.