### PR TITLE
168 user has infiltration rasters defined but no simple infiltration referral in the global settings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,11 @@ Changelog of threedi-modelchecker
   argument. The check output can also be dumped to a file using ``--file``.
 
 - Compatibility fix with rasterio 1.3.6.
+
 - Drop SQLAlchemy 1.3 support, add 2.0 support.
+
+- Add check 326: this gives an info message if a record exists in the simple_infiltration
+  table, but is not referenced from the global settings.
 
 
 1.0.1 (2023-02-02)

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -1139,6 +1139,15 @@ CHECKS += [
         ),
         message="v2_global_settings.interception_global is recommended as fallback value when using an interception_file.",
     ),
+    QueryCheck(
+        error_code=326,
+        level=CheckLevel.INFO,
+        column=models.SimpleInfiltration.id,
+        invalid=Query(models.SimpleInfiltration)
+        .join(models.GlobalSetting, models.SimpleInfiltration.id == models.GlobalSetting.simple_infiltration_settings_id, isouter=True)
+        .where(models.GlobalSetting.simple_infiltration_settings_id == None),
+        message="v2_simple_infiltration is defined, but not referred to in v2_global_settings.simple_infiltration_settings_id",
+    ),
 ]
 
 CHECKS += [

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -1158,6 +1158,7 @@ CHECKS += [
         (models.Interflow, models.GlobalSetting.interflow_settings_id),
         (models.GroundWater, models.GlobalSetting.groundwater_settings_id),
         (models.NumericalSettings, models.GlobalSetting.numerical_settings_id),
+        (models.ControlGroup, models.GlobalSetting.control_group_id),
     )
 ]
 

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -1143,14 +1143,9 @@ CHECKS += [
         error_code=326,
         level=CheckLevel.INFO,
         column=models.SimpleInfiltration.id,
-        invalid=Query(models.SimpleInfiltration)
-        .join(
-            models.GlobalSetting,
-            models.SimpleInfiltration.id
-            == models.GlobalSetting.simple_infiltration_settings_id,
-            isouter=True,
-        )
-        .where(models.GlobalSetting.simple_infiltration_settings_id == None),
+        invalid=Query(models.SimpleInfiltration).filter(
+            models.SimpleInfiltration.id != Query(models.GlobalSetting.simple_infiltration_settings_id).filter(first_setting_filter).scalar_subquery()
+        ),
         message="v2_simple_infiltration is defined, but not referred to in v2_global_settings.simple_infiltration_settings_id",
     ),
 ]

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -1144,7 +1144,12 @@ CHECKS += [
         level=CheckLevel.INFO,
         column=models.SimpleInfiltration.id,
         invalid=Query(models.SimpleInfiltration)
-        .join(models.GlobalSetting, models.SimpleInfiltration.id == models.GlobalSetting.simple_infiltration_settings_id, isouter=True)
+        .join(
+            models.GlobalSetting,
+            models.SimpleInfiltration.id
+            == models.GlobalSetting.simple_infiltration_settings_id,
+            isouter=True,
+        )
         .where(models.GlobalSetting.simple_infiltration_settings_id == None),
         message="v2_simple_infiltration is defined, but not referred to in v2_global_settings.simple_infiltration_settings_id",
     ),

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -1144,6 +1144,7 @@ CHECKS += [
 CHECKS += [
     QueryCheck(
         error_code=326,
+        level=CheckLevel.INFO,
         column=table.id,
         invalid=Query(table).filter(
             table.id != Query(setting).filter(first_setting_filter).scalar_subquery()

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -1151,7 +1151,10 @@ CHECKS += [
         message=f"{table.__tablename__} is defined, but not referred to in v2_global_settings.{setting.name}",
     )
     for table, setting in (
-        (models.SimpleInfiltration, models.GlobalSetting.simple_infiltration_settings_id),
+        (
+            models.SimpleInfiltration,
+            models.GlobalSetting.simple_infiltration_settings_id,
+        ),
         (models.Interflow, models.GlobalSetting.interflow_settings_id),
         (models.GroundWater, models.GlobalSetting.groundwater_settings_id),
         (models.NumericalSettings, models.GlobalSetting.numerical_settings_id),

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -1139,15 +1139,23 @@ CHECKS += [
         ),
         message="v2_global_settings.interception_global is recommended as fallback value when using an interception_file.",
     ),
+]
+
+CHECKS += [
     QueryCheck(
         error_code=326,
-        level=CheckLevel.INFO,
-        column=models.SimpleInfiltration.id,
-        invalid=Query(models.SimpleInfiltration).filter(
-            models.SimpleInfiltration.id != Query(models.GlobalSetting.simple_infiltration_settings_id).filter(first_setting_filter).scalar_subquery()
+        column=table.id,
+        invalid=Query(table).filter(
+            table.id != Query(setting).filter(first_setting_filter).scalar_subquery()
         ),
-        message="v2_simple_infiltration is defined, but not referred to in v2_global_settings.simple_infiltration_settings_id",
-    ),
+        message=f"{table.__tablename__} is defined, but not referred to in v2_global_settings.{setting.name}",
+    )
+    for table, setting in (
+        (models.SimpleInfiltration, models.GlobalSetting.simple_infiltration_settings_id),
+        (models.Interflow, models.GlobalSetting.interflow_settings_id),
+        (models.GroundWater, models.GlobalSetting.groundwater_settings_id),
+        (models.NumericalSettings, models.GlobalSetting.numerical_settings_id),
+    )
 ]
 
 CHECKS += [


### PR DESCRIPTION
If a record in the v2_simple_infiltration table exists but is not referenced from v2_global_settings, this gives an info message notifying the user.