### PR TITLE
227 compare global settings grid size with the dem cell size

### DIFF
--- a/threedi_modelchecker/checks/raster.py
+++ b/threedi_modelchecker/checks/raster.py
@@ -216,7 +216,11 @@ class RasterGridSizeCheck(BaseRasterCheck):
     """
 
     def get_invalid(self, session):
-        self.grid_space = session.query(models.GlobalSetting.grid_space).first()[0]
+        grid_space_query = session.query(models.GlobalSetting.grid_space).first()
+        if grid_space_query is not None:
+            self.grid_space = grid_space_query[0]
+        else:
+            return []
         return super().get_invalid(session)
 
     def is_valid(self, path: str, interface_cls: Type[RasterInterface]):

--- a/threedi_modelchecker/checks/raster.py
+++ b/threedi_modelchecker/checks/raster.py
@@ -100,8 +100,6 @@ class RasterExistsCheck(BaseRasterCheck):
 
 class RasterIsValidCheck(BaseRasterCheck):
     """Check whether a file is a geotiff.
-
-    Only works locally.
     """
 
     def is_valid(self, path: str, interface_cls: Type[RasterInterface]):
@@ -114,8 +112,6 @@ class RasterIsValidCheck(BaseRasterCheck):
 
 class RasterHasOneBandCheck(BaseRasterCheck):
     """Check whether a raster has a single band.
-
-    Only works locally.
     """
 
     def is_valid(self, path: str, interface_cls: Type[RasterInterface]):
@@ -130,8 +126,6 @@ class RasterHasOneBandCheck(BaseRasterCheck):
 
 class RasterHasProjectionCheck(BaseRasterCheck):
     """Check whether a raster has a projected coordinate system.
-
-    Only works locally.
     """
 
     def is_valid(self, path: str, interface_cls: Type[RasterInterface]):
@@ -146,8 +140,6 @@ class RasterHasProjectionCheck(BaseRasterCheck):
 
 class RasterIsProjectedCheck(BaseRasterCheck):
     """Check whether a raster has a projected coordinate system.
-
-    Only works locally.
     """
 
     def is_valid(self, path: str, interface_cls: Type[RasterInterface]):
@@ -162,8 +154,6 @@ class RasterIsProjectedCheck(BaseRasterCheck):
 
 class RasterHasMatchingEPSGCheck(BaseRasterCheck):
     """Check whether a raster's EPSG code matches the EPSG code in the global settings for the SQLite.
-
-    Only works locally.
     """
 
     def get_invalid(self, session):
@@ -188,8 +178,6 @@ class RasterHasMatchingEPSGCheck(BaseRasterCheck):
 
 class RasterSquareCellsCheck(BaseRasterCheck):
     """Check whether a raster has square cells (pixels)
-
-    Only works locally.
     """
 
     def __init__(self, *args, decimals=7, **kwargs):
@@ -211,8 +199,6 @@ class RasterSquareCellsCheck(BaseRasterCheck):
 
 class RasterGridSizeCheck(BaseRasterCheck):
     """Check whether the global settings' grid size is an even multiple of a raster's cell size (at least 2x).
-
-    Only works locally.
     """
 
     def get_invalid(self, session):
@@ -239,7 +225,7 @@ class RasterGridSizeCheck(BaseRasterCheck):
 class RasterRangeCheck(BaseRasterCheck):
     """Check whether a raster has values outside of provided range.
 
-    Also fails when there are no values in the raster. Only works locally.
+    Also fails when there are no values in the raster.
     """
 
     def __init__(

--- a/threedi_modelchecker/checks/raster.py
+++ b/threedi_modelchecker/checks/raster.py
@@ -99,8 +99,7 @@ class RasterExistsCheck(BaseRasterCheck):
 
 
 class RasterIsValidCheck(BaseRasterCheck):
-    """Check whether a file is a geotiff.
-    """
+    """Check whether a file is a geotiff."""
 
     def is_valid(self, path: str, interface_cls: Type[RasterInterface]):
         with interface_cls(path) as raster:
@@ -111,8 +110,7 @@ class RasterIsValidCheck(BaseRasterCheck):
 
 
 class RasterHasOneBandCheck(BaseRasterCheck):
-    """Check whether a raster has a single band.
-    """
+    """Check whether a raster has a single band."""
 
     def is_valid(self, path: str, interface_cls: Type[RasterInterface]):
         with interface_cls(path) as raster:
@@ -125,8 +123,7 @@ class RasterHasOneBandCheck(BaseRasterCheck):
 
 
 class RasterHasProjectionCheck(BaseRasterCheck):
-    """Check whether a raster has a projected coordinate system.
-    """
+    """Check whether a raster has a projected coordinate system."""
 
     def is_valid(self, path: str, interface_cls: Type[RasterInterface]):
         with interface_cls(path) as raster:
@@ -139,8 +136,7 @@ class RasterHasProjectionCheck(BaseRasterCheck):
 
 
 class RasterIsProjectedCheck(BaseRasterCheck):
-    """Check whether a raster has a projected coordinate system.
-    """
+    """Check whether a raster has a projected coordinate system."""
 
     def is_valid(self, path: str, interface_cls: Type[RasterInterface]):
         with interface_cls(path) as raster:
@@ -153,8 +149,7 @@ class RasterIsProjectedCheck(BaseRasterCheck):
 
 
 class RasterHasMatchingEPSGCheck(BaseRasterCheck):
-    """Check whether a raster's EPSG code matches the EPSG code in the global settings for the SQLite.
-    """
+    """Check whether a raster's EPSG code matches the EPSG code in the global settings for the SQLite."""
 
     def get_invalid(self, session):
         epsg_code_query = session.query(models.GlobalSetting.epsg_code).first()
@@ -177,8 +172,7 @@ class RasterHasMatchingEPSGCheck(BaseRasterCheck):
 
 
 class RasterSquareCellsCheck(BaseRasterCheck):
-    """Check whether a raster has square cells (pixels)
-    """
+    """Check whether a raster has square cells (pixels)"""
 
     def __init__(self, *args, decimals=7, **kwargs):
         super().__init__(*args, **kwargs)
@@ -198,8 +192,7 @@ class RasterSquareCellsCheck(BaseRasterCheck):
 
 
 class RasterGridSizeCheck(BaseRasterCheck):
-    """Check whether the global settings' grid size is an even multiple of a raster's cell size (at least 2x).
-    """
+    """Check whether the global settings' grid size is an even multiple of a raster's cell size (at least 2x)."""
 
     def get_invalid(self, session):
         grid_space_query = session.query(models.GlobalSetting.grid_space).first()

--- a/threedi_modelchecker/checks/raster.py
+++ b/threedi_modelchecker/checks/raster.py
@@ -212,7 +212,7 @@ class RasterGridSizeCheck(BaseRasterCheck):
             )
 
     def description(self):
-        return f"{self.column_name} is not a positive even multiple of the raster cell size."
+        return f"v2_global_settings.grid_space is not a positive even multiple of the raster cell size."
 
 
 class RasterRangeCheck(BaseRasterCheck):

--- a/threedi_modelchecker/checks/raster.py
+++ b/threedi_modelchecker/checks/raster.py
@@ -212,7 +212,7 @@ class RasterGridSizeCheck(BaseRasterCheck):
             )
 
     def description(self):
-        return f"v2_global_settings.grid_space is not a positive even multiple of the raster cell size."
+        return "v2_global_settings.grid_space is not a positive even multiple of the raster cell size."
 
 
 class RasterRangeCheck(BaseRasterCheck):

--- a/threedi_modelchecker/checks/raster.py
+++ b/threedi_modelchecker/checks/raster.py
@@ -227,15 +227,13 @@ class RasterGridSizeCheck(BaseRasterCheck):
         with interface_cls(path) as raster:
             if not raster.is_valid_geotiff:
                 return True
-            if raster.pixel_size is None:
-                return False
             # the x pixel size is used here,but it is equal to the y pixel size
             return ((self.grid_space / raster.pixel_size[0]) % 2 == 0) and (
                 self.grid_space >= (2 * raster.pixel_size[0])
             )
 
     def description(self):
-        return f"The cell size for the file in {self.column_name} is undefined, or the global grid space is not a positive even multiple of the file's cell size."
+        return f"{self.column_name} is not a positive even multiple of the raster cell size."
 
 
 class RasterRangeCheck(BaseRasterCheck):

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -1849,7 +1849,7 @@ CHECKS += [
     ),
     RasterGridSizeCheck(
         error_code=798,
-        column=models.GlobalSetting.grid_space,
+        column=models.GlobalSetting.dem_file,
         filters=first_setting_filter,
     ),
 ]

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -54,6 +54,7 @@ from .checks.other import (
 from .checks.raster import (
     GDALAvailableCheck,
     RasterExistsCheck,
+    RasterGridSizeCheck,
     RasterHasMatchingEPSGCheck,
     RasterHasOneBandCheck,
     RasterHasProjectionCheck,
@@ -1844,6 +1845,11 @@ CHECKS += [
         error_code=797,
         level=CheckLevel.WARNING,
         column=models.GlobalSetting.dem_file,
+        filters=first_setting_filter,
+    ),
+    RasterGridSizeCheck(
+        error_code=798,
+        column=models.GlobalSetting.grid_space,
         filters=first_setting_filter,
     ),
 ]

--- a/threedi_modelchecker/tests/test_checks_raster.py
+++ b/threedi_modelchecker/tests/test_checks_raster.py
@@ -346,7 +346,7 @@ def test_raster_grid_size(
     path = create_geotiff(
         tmp_path / "raster.tiff", dx=raster_pixel_size, dy=raster_pixel_size
     )
-    check = RasterGridSizeCheck(column=models.GlobalSetting.dem_file)
+    check = RasterGridSizeCheck(column=models.GlobalSetting.grid_space)
     check.grid_space = sqlite_grid_space
     assert check.is_valid(path, interface_cls) == validity
 
@@ -401,6 +401,7 @@ def test_raster_range_no_data(tmp_path, interface_cls):
         RasterHasMatchingEPSGCheck(column=models.GlobalSetting.dem_file),
         RasterIsProjectedCheck(column=models.GlobalSetting.dem_file),
         RasterSquareCellsCheck(column=models.GlobalSetting.dem_file),
+        RasterGridSizeCheck(column=models.GlobalSetting.grid_space),
         RasterRangeCheck(column=models.GlobalSetting.dem_file, min_value=0),
     ],
 )

--- a/threedi_modelchecker/tests/test_checks_raster.py
+++ b/threedi_modelchecker/tests/test_checks_raster.py
@@ -334,6 +334,7 @@ def test_square_cells_rounding(tmp_path, interface_cls):
 @pytest.mark.parametrize(
     "raster_pixel_size, sqlite_grid_space, validity",
     [
+        (2, 7, False),
         (2, 4, True),
         (2, 3, False),
         (2, 0, False),

--- a/threedi_modelchecker/tests/test_checks_raster.py
+++ b/threedi_modelchecker/tests/test_checks_raster.py
@@ -347,7 +347,7 @@ def test_raster_grid_size(
     path = create_geotiff(
         tmp_path / "raster.tiff", dx=raster_pixel_size, dy=raster_pixel_size
     )
-    check = RasterGridSizeCheck(column=models.GlobalSetting.grid_space)
+    check = RasterGridSizeCheck(column=models.GlobalSetting.dem_file)
     check.grid_space = sqlite_grid_space
     assert check.is_valid(path, interface_cls) == validity
 
@@ -402,7 +402,7 @@ def test_raster_range_no_data(tmp_path, interface_cls):
         RasterHasMatchingEPSGCheck(column=models.GlobalSetting.dem_file),
         RasterIsProjectedCheck(column=models.GlobalSetting.dem_file),
         RasterSquareCellsCheck(column=models.GlobalSetting.dem_file),
-        RasterGridSizeCheck(column=models.GlobalSetting.grid_space),
+        RasterGridSizeCheck(column=models.GlobalSetting.dem_file),
         RasterRangeCheck(column=models.GlobalSetting.dem_file, min_value=0),
     ],
 )


### PR DESCRIPTION
This check raises an error if
- `RasterInterface.pixel_size` is `None`
- `GlobalSettings.grid_space` is not an even multiple of `RasterInterface.pixel_size`
- `GlobalSettings.grid_space` is less than 2× `RasterInterface.pixel_size`