### PR TITLE
245 check storage area at node pump is sufficient empty pump cellar in some time not one timestep

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,8 @@ Changelog of threedi-modelchecker
 - Add check 326: this gives an info message if a record exists in the simple_infiltration
   table, but is not referenced from the global settings.
 
+- Add check 66: this raises a warning if a pumpstation empties its storage area in less than one timestep.
+
 
 1.0.1 (2023-02-02)
 ------------------

--- a/threedi_modelchecker/checks/other.py
+++ b/threedi_modelchecker/checks/other.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import List, Literal, NamedTuple
 
-from sqlalchemy import func, text
+from sqlalchemy import case, func, text
 from sqlalchemy.orm import aliased, Query, Session
 from threedi_schema import constants, models
 
@@ -528,14 +528,20 @@ class PumpStorageTimestepCheck(BaseCheck):
             .filter(
                 (  # calculate how many seconds the pumpstation takes to empty its storage: (storage * height)/pump capacity
                     (
-                        models.ConnectionNode.storage_area
+                        # Arithmetic operations on None return None, so without this
+                        # conditional type cast, 0 invalid results would be returned
+                        # even if the storage_area was set to None.
+                        case(
+                            (models.ConnectionNode.storage_area == None, 0),
+                            else_=models.ConnectionNode.storage_area,
+                        )
                         * (
                             models.Pumpstation.start_level
                             - models.Pumpstation.lower_stop_level
                         )
                     )
-                    / models.Pumpstation.capacity
                 )
+                / models.Pumpstation.capacity
                 < Query(models.GlobalSetting.sim_time_step)
                 .filter(first_setting_filter)
                 .scalar_subquery()

--- a/threedi_modelchecker/checks/other.py
+++ b/threedi_modelchecker/checks/other.py
@@ -507,7 +507,7 @@ class PotentialBreachInterdistanceCheck(BaseCheck):
 
 
 class PumpStorageTimestepCheck(BaseCheck):
-    """Checks whether a will empty its storage area within one timestep"""
+    """Check that a pumpstation will not empty its storage area within one timestep"""
 
     def get_invalid(self, session: Session) -> List[NamedTuple]:
         return (
@@ -519,7 +519,7 @@ class PumpStorageTimestepCheck(BaseCheck):
             .filter(
                 (models.ConnectionNode.storage_area != None)
                 & (
-                    (
+                    (  # calculate how many seconds the pumpstation takes to empty its storage: (storage * height)/pump capacity
                         (
                             models.ConnectionNode.storage_area
                             * (

--- a/threedi_modelchecker/checks/other.py
+++ b/threedi_modelchecker/checks/other.py
@@ -529,7 +529,7 @@ class PumpStorageTimestepCheck(BaseCheck):
                 (  # calculate how many seconds the pumpstation takes to empty its storage: (storage * height)/pump capacity
                     (
                         # Arithmetic operations on None return None, so without this
-                        # conditional type cast, 0 invalid results would be returned
+                        # conditional type cast, no invalid results would be returned
                         # even if the storage_area was set to None.
                         case(
                             (models.ConnectionNode.storage_area == None, 0),

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -48,6 +48,7 @@ from .checks.other import (
     OpenChannelsWithNestedNewton,
     PotentialBreachInterdistanceCheck,
     PotentialBreachStartEndCheck,
+    PumpStorageTimestepCheck,
     SpatialIndexCheck,
     Use0DFlowCheck,
 )
@@ -332,36 +333,10 @@ CHECKS += [
         invalid=Query(models.Pumpstation).filter(models.Pumpstation.capacity == 0.0),
         message="v2_pumpstation.capacity should be be greater than 0",
     ),
-    QueryCheck(
+    PumpStorageTimestepCheck(
         error_code=66,
         level=CheckLevel.WARNING,
         column=models.Pumpstation.capacity,
-        invalid=Query(models.Pumpstation)
-        .join(
-            models.ConnectionNode,
-            models.Pumpstation.connection_node_start_id == models.ConnectionNode.id,
-        )
-        .filter(
-            (models.ConnectionNode.storage_area != None)
-            & (
-                (
-                    (
-                        models.ConnectionNode.storage_area
-                        * (
-                            models.Pumpstation.start_level
-                            - models.Pumpstation.lower_stop_level
-                        )
-                    )
-                    / models.Pumpstation.capacity
-                )
-                < (
-                    Query(models.GlobalSetting.sim_time_step)
-                    .filter(first_setting_filter)
-                    .scalar_subquery()
-                )
-            )
-        ),
-        message="v2_pumpstation will empty its storage faster than one timestep, which can cause simulation instabilities",
     ),
 ]
 

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -332,6 +332,37 @@ CHECKS += [
         invalid=Query(models.Pumpstation).filter(models.Pumpstation.capacity == 0.0),
         message="v2_pumpstation.capacity should be be greater than 0",
     ),
+    QueryCheck(
+        error_code=66,
+        level=CheckLevel.WARNING,
+        column=models.Pumpstation.capacity,
+        invalid=Query(models.Pumpstation)
+        .join(
+            models.ConnectionNode,
+            models.Pumpstation.connection_node_start_id == models.ConnectionNode.id,
+        )
+        .filter(
+            (models.ConnectionNode.storage_area != None)
+            & (
+                (
+                    (
+                        models.ConnectionNode.storage_area
+                        * (
+                            models.Pumpstation.start_level
+                            - models.Pumpstation.lower_stop_level
+                        )
+                    )
+                    / models.Pumpstation.capacity
+                )
+                < (
+                    Query(models.GlobalSetting.sim_time_step)
+                    .filter(first_setting_filter)
+                    .scalar_subquery()
+                )
+            )
+        ),
+        message="v2_pumpstation will empty its storage faster than one timestep, which can cause simulation instabilities",
+    ),
 ]
 
 ## 007x: BOUNDARY CONDITIONS

--- a/threedi_modelchecker/tests/test_checks_other.py
+++ b/threedi_modelchecker/tests/test_checks_other.py
@@ -370,21 +370,23 @@ def test_potential_breach_interdistance_other_channel(session):
 
 
 @pytest.mark.parametrize(
-    "storage_area,time_step,expected_result",
+    "storage_area,time_step,expected_result,capacity",
     [
-        (0.64, 30, 1),
-        (600, 30, 0),
+        (0.64, 30, 1, 12.5),
+        (600, 30, 0, 12.5),
+        (None, 30, 1, 12.5),
+        (600, 30, 0, 0),
     ],
 )
 def test_pumpstation_storage_timestep(
-    session, storage_area, time_step, expected_result
+    session, storage_area, time_step, expected_result, capacity
 ):
     connection_node = factories.ConnectionNodeFactory(storage_area=storage_area)
     factories.PumpstationFactory(
         connection_node_start=connection_node,
         start_level=-4,
         lower_stop_level=-4.78,
-        capacity=12.5,
+        capacity=capacity,
     )
     factories.GlobalSettingsFactory(sim_time_step=time_step)
     check = PumpStorageTimestepCheck(models.Pumpstation.capacity)

--- a/threedi_modelchecker/tests/test_checks_other.py
+++ b/threedi_modelchecker/tests/test_checks_other.py
@@ -374,7 +374,7 @@ def test_potential_breach_interdistance_other_channel(session):
     [
         (0.64, 30, 1, 12.5),
         (600, 30, 0, 12.5),
-        (None, 30, 1, 12.5),
+        (None, 30, 0, 12.5),  # no storage --> open water --> no check
         (600, 30, 0, 0),
     ],
 )


### PR DESCRIPTION
This check raises a WARNING if a pumpstation is configured such that it will empty its storage in less than one simulation timestep, since that can lead to simulation instabilities.