### PR TITLE
1774 all boundary condition timeseries need to have the same timestamps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,8 @@ Changelog of threedi-modelchecker
 
 - Add check 1205 to make sure that a timeseries is not an empty string.
 
+- Add checks 1206 to confirm that the timesteps in all boundary condition timesteps are the same.
+
 
 1.0.1 (2023-02-02)
 ------------------

--- a/threedi_modelchecker/checks/timeseries.py
+++ b/threedi_modelchecker/checks/timeseries.py
@@ -108,17 +108,20 @@ class FirstTimeSeriesEqualTimestepsCheck(BaseCheck):
         )
 
         if first_1d_timeseries and first_2d_timeseries:
-            if not compare_timesteps(
-                first_timeseries=first_1d_timeseries[0][2],
-                second_timeseries=first_2d_timeseries[0][2],
-            ):
-                invalid_timeseries.append(first_1d_timeseries[0])
+            try:
+                if not compare_timesteps(
+                    first_timeseries=first_1d_timeseries[0].timeseries,
+                    second_timeseries=first_2d_timeseries[0].timeseries,
+                ):
+                    invalid_timeseries.append(first_1d_timeseries[0])
+            except Exception:  # other checks will catch these
+                pass
 
         return invalid_timeseries
 
     def description(self):
         return (
-            "The timesteps for the first v2_1d_boundary_conditions.timeseries did not match the timesteps for the first v2_2d_boundary_conditions. "
+            "The timesteps for the first v2_1d_boundary_conditions.timeseries did not match the timesteps for the first v2_2d_boundary_conditions.timeseries. "
             + "All boundary conditions must have the same timesteps in their timeseries."
         )
 

--- a/threedi_modelchecker/checks/timeseries.py
+++ b/threedi_modelchecker/checks/timeseries.py
@@ -1,4 +1,3 @@
-from sqlalchemy import select
 from threedi_schema import models
 
 from .base import BaseCheck
@@ -13,6 +12,7 @@ def parse_timeseries(timeseries_str):
         timestep = int(timestep.strip())
         output.append([timestep, float(value.strip())])
     return output
+
 
 def compare_timesteps(first_timeseries: str, second_timeseries: str) -> bool:
     first_timesteps = [pair[0] for pair in parse_timeseries(first_timeseries)]
@@ -93,22 +93,24 @@ class FirstTimeSeriesEqualTimestepsCheck(BaseCheck):
     def get_invalid(self, session):
         invalid_timeseries = []
 
-        first_1d_timeseries = session.query(
-            models.BoundaryCondition1D.timeseries.table
-        ).order_by(
-            models.BoundaryCondition1D.id
-        ).limit(1).all()
+        first_1d_timeseries = (
+            session.query(models.BoundaryCondition1D.timeseries.table)
+            .order_by(models.BoundaryCondition1D.id)
+            .limit(1)
+            .all()
+        )
 
-        first_2d_timeseries = session.query(
-            models.BoundaryConditions2D.timeseries.table
-        ).order_by(
-            models.BoundaryConditions2D.id
-        ).limit(1).all()
+        first_2d_timeseries = (
+            session.query(models.BoundaryConditions2D.timeseries.table)
+            .order_by(models.BoundaryConditions2D.id)
+            .limit(1)
+            .all()
+        )
 
         if first_1d_timeseries and first_2d_timeseries:
             if not compare_timesteps(
                 first_timeseries=first_1d_timeseries[0][2],
-                second_timeseries=first_2d_timeseries[0][2]
+                second_timeseries=first_2d_timeseries[0][2],
             ):
                 invalid_timeseries.append(first_1d_timeseries[0])
 
@@ -116,8 +118,8 @@ class FirstTimeSeriesEqualTimestepsCheck(BaseCheck):
 
     def description(self):
         return (
-            "The timesteps for the first v2_1d_boundary_conditions.timeseries did not match the timesteps for the first v2_2d_boundary_conditions. " +
-            "All boundary conditions must have the same timesteps in their timeseries."
+            "The timesteps for the first v2_1d_boundary_conditions.timeseries did not match the timesteps for the first v2_2d_boundary_conditions. "
+            + "All boundary conditions must have the same timesteps in their timeseries."
         )
 
 

--- a/threedi_modelchecker/checks/timeseries.py
+++ b/threedi_modelchecker/checks/timeseries.py
@@ -14,6 +14,11 @@ def parse_timeseries(timeseries_str):
         output.append([timestep, float(value.strip())])
     return output
 
+def compare_timesteps(first_timeseries: str, second_timeseries: str) -> bool:
+    first_timesteps = [pair[0] for pair in parse_timeseries(first_timeseries)]
+    second_timesteps = [pair[0] for pair in parse_timeseries(second_timeseries)]
+    return first_timesteps == second_timesteps
+
 
 class TimeseriesExistenceCheck(BaseCheck):
     """Check that an empty timeseries has not been provided."""
@@ -33,54 +38,17 @@ class TimeseriesExistenceCheck(BaseCheck):
 
 class TimeSeriesEqualTimestepsCheck(BaseCheck):
     """
-    Check that the timesteps in all boundary condition timeseries are equal.
+    Check that the timesteps in all timeseries in a column are equal.
 
-    This checks the timesteps for all timeseries against the timesteps in the first 1D boundary
-    condition timeseries, or if that doesn't exist, the first 2D boundary condition timeseries.
-    Consequently, if the first timeseries is wrong, all the other boundary conditions will raise
-    give a warning.
+    This checks the timesteps for all timeseries in a column against the timesteps in the first
+    timeseries in that column. Consequently, if the first timeseries is wrong, all the other boundary
+    conditions will raise a warning.
     """
-
-    def compare_timesteps(self, first_timeseries: str, second_timeseries: str) -> bool:
-        first_timesteps = [pair[0] for pair in parse_timeseries(first_timeseries)]
-        second_timesteps = [pair[0] for pair in parse_timeseries(second_timeseries)]
-        return first_timesteps == second_timesteps
 
     def get_invalid(self, session):
         invalid_timeseries = []
 
-        # set the first timeseries variable to None if the timeseries column is empty
-        # using a walrus operator avoids running the query both for checking emptiness and for fetching the value
-        first_1d_timeseries = (
-            timeseries_query[0][0]
-            if (
-                timeseries_query := session.execute(
-                    select(models.BoundaryCondition1D.timeseries)
-                    .order_by(models.BoundaryCondition1D.id)
-                    .limit(1)
-                ).all()
-            )
-            else None
-        )
-
-        first_2d_timeseries = (
-            timeseries_query[0][0]
-            if (
-                timeseries_query := session.execute(
-                    select(models.BoundaryConditions2D.timeseries)
-                    .order_by(models.BoundaryConditions2D.id)
-                    .limit(1)
-                ).all()
-            )
-            else None
-        )
-
-        # if both the 1d and 2d boundary conditions are empty there are no timeseries, so also no nonmatching ones
-        if not first_1d_timeseries and not first_2d_timeseries:
-            return []
-
-        # use to properly format the error description
-        self.one_d_timeseries_used = True if first_1d_timeseries else False
+        first_timeseries = None
 
         for row in self.to_check(session).all():
             timeseries = row.timeseries
@@ -88,10 +56,12 @@ class TimeSeriesEqualTimestepsCheck(BaseCheck):
             if not timeseries:
                 continue
 
-            if not self.compare_timesteps(
-                first_timeseries=(
-                    first_1d_timeseries if first_1d_timeseries else first_2d_timeseries
-                ),
+            if not first_timeseries:
+                first_timeseries = timeseries
+                continue  # don't compare first timeseries with itself
+
+            if not compare_timesteps(
+                first_timeseries=first_timeseries,
                 second_timeseries=timeseries,
             ):
                 invalid_timeseries.append(row)
@@ -100,8 +70,7 @@ class TimeSeriesEqualTimestepsCheck(BaseCheck):
 
     def description(self):
         return (
-            f"One or more timesteps in {self.column_name} did not match the first timeseries in this "
-            + f"models.BoundaryCondition{'1D' if self.one_d_timeseries_used else 's2D'}.timeseries. "
+            f"One or more timesteps in {self.column_name} did not match the timesteps in the first timeseries in the column."
             + "The timesteps in all timeseries must be the same."
         )
 

--- a/threedi_modelchecker/checks/timeseries.py
+++ b/threedi_modelchecker/checks/timeseries.py
@@ -62,11 +62,14 @@ class TimeSeriesEqualTimestepsCheck(BaseCheck):
                 first_timeseries = timeseries
                 continue  # don't compare first timeseries with itself
 
-            if not compare_timesteps(
-                first_timeseries=first_timeseries,
-                second_timeseries=timeseries,
-            ):
-                invalid_timeseries.append(row)
+            try:
+                if not compare_timesteps(
+                    first_timeseries=first_timeseries,
+                    second_timeseries=timeseries,
+                ):
+                    invalid_timeseries.append(row)
+            except Exception:  # other checks will catch these
+                pass
 
         return invalid_timeseries
 

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -2160,7 +2160,7 @@ CHECKS += [
         models.BoundaryConditions2D.timeseries,
     ]
 ]
-CHECKS += [FirstTimeSeriesEqualTimestepsCheck()]
+CHECKS += [FirstTimeSeriesEqualTimestepsCheck(error_code=1206)]
 
 ## 122x Structure controls
 

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -65,8 +65,8 @@ from .checks.raster import (
     RasterSquareCellsCheck,
 )
 from .checks.timeseries import (
-    TimeSeriesEqualTimestepsCheck,
     FirstTimeSeriesEqualTimestepsCheck,
+    TimeSeriesEqualTimestepsCheck,
     TimeseriesExistenceCheck,
     TimeseriesIncreasingCheck,
     TimeseriesRowCheck,

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -65,6 +65,7 @@ from .checks.raster import (
     RasterSquareCellsCheck,
 )
 from .checks.timeseries import (
+    TimeSeriesEqualTimestepsCheck,
     TimeseriesExistenceCheck,
     TimeseriesIncreasingCheck,
     TimeseriesRowCheck,
@@ -2146,6 +2147,13 @@ CHECKS += [
 ]
 CHECKS += [
     TimeseriesExistenceCheck(col, error_code=1205)
+    for col in [
+        models.BoundaryCondition1D.timeseries,
+        models.BoundaryConditions2D.timeseries,
+    ]
+]
+CHECKS += [
+    TimeSeriesEqualTimestepsCheck(col, error_code=1206)
     for col in [
         models.BoundaryCondition1D.timeseries,
         models.BoundaryConditions2D.timeseries,

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -66,6 +66,7 @@ from .checks.raster import (
 )
 from .checks.timeseries import (
     TimeSeriesEqualTimestepsCheck,
+    FirstTimeSeriesEqualTimestepsCheck,
     TimeseriesExistenceCheck,
     TimeseriesIncreasingCheck,
     TimeseriesRowCheck,
@@ -2159,6 +2160,7 @@ CHECKS += [
         models.BoundaryConditions2D.timeseries,
     ]
 ]
+CHECKS += [FirstTimeSeriesEqualTimestepsCheck()]
 
 ## 122x Structure controls
 

--- a/threedi_modelchecker/tests/test_checks_timeseries.py
+++ b/threedi_modelchecker/tests/test_checks_timeseries.py
@@ -15,18 +15,29 @@ from threedi_modelchecker.checks.timeseries import (
 from .factories import BoundaryConditions1DFactory, BoundaryConditions2DFactory
 
 
-@pytest.mark.parametrize("check_type", ["1d","2d"])
+@pytest.mark.parametrize("check_type", ["1d", "2d"])
 @pytest.mark.parametrize(
-        "timeseries_tuple,expected_invalid",
-        [
-            ((),0), # no timeseries
-            (("0,-0.5 \n59,-0.2", "0,-0.5 \n59,-0.2"),0), # same levels
-            (("0,-0.5 \n59,-0.2", "0,-0.5 \n59,-0.3"),0), # same timesteps, different levels
-            (("0,-0.5 \n59,-0.2", "0,-0.5 \n58,-0.3", "0,-0.5 \n59,-0.3"),1), # differing timestep, one error
-            (("0,-0.5 \n58,-0.2", "0,-0.5 \n59,-0.3", "0,-0.5 \n59,-0.3"),2), # differing first timestep, all other timeseries error
-        ]
-    )
-def test_timeseries_same_timesteps(session, timeseries_tuple, check_type, expected_invalid):
+    "timeseries_tuple,expected_invalid",
+    [
+        ((), 0),  # no timeseries
+        (("0,-0.5 \n59,-0.2", "0,-0.5 \n59,-0.2"), 0),  # same levels
+        (
+            ("0,-0.5 \n59,-0.2", "0,-0.5 \n59,-0.3"),
+            0,
+        ),  # same timesteps, different levels
+        (
+            ("0,-0.5 \n59,-0.2", "0,-0.5 \n58,-0.3", "0,-0.5 \n59,-0.3"),
+            1,
+        ),  # differing timestep, one error
+        (
+            ("0,-0.5 \n58,-0.2", "0,-0.5 \n59,-0.3", "0,-0.5 \n59,-0.3"),
+            2,
+        ),  # differing first timestep, all other timeseries error
+    ],
+)
+def test_timeseries_same_timesteps(
+    session, timeseries_tuple, check_type, expected_invalid
+):
     if check_type == "1d":
         for timeseries in timeseries_tuple:
             BoundaryConditions1DFactory(timeseries=timeseries)
@@ -40,16 +51,26 @@ def test_timeseries_same_timesteps(session, timeseries_tuple, check_type, expect
 
 
 @pytest.mark.parametrize(
-        "one_d_timeseries_tuple,two_d_timeseries_tuple,expected_invalid",
-        [
-            ((),(),0), # no timeseries
-            (("0,-0.5 \n59,-0.2", "0,-0.5 \n59,-0.2"),(),0), # no 2d timeseries
-            ((), ("0,-0.5 \n59,-0.2", "0,-0.5 \n59,-0.2"),0), # no 1d timeseries
-            (("0,-0.5 \n59,-0.2", "0,-0.5 \n59,-0.2"), ("0,-0.5 \n59,-0.2", "0,-0.5 \n58,-0.2"),0), # differing second element
-            (("0,-0.5 \n59,-0.2", "0,-0.5 \n59,-0.2"), ("0,-0.5 \n58,-0.2", "0,-0.5 \n59,-0.2"),1), # differing first element
-        ]
-    )
-def test_first_timeseries_same_timesteps(session, one_d_timeseries_tuple, two_d_timeseries_tuple, expected_invalid):
+    "one_d_timeseries_tuple,two_d_timeseries_tuple,expected_invalid",
+    [
+        ((), (), 0),  # no timeseries
+        (("0,-0.5 \n59,-0.2", "0,-0.5 \n59,-0.2"), (), 0),  # no 2d timeseries
+        ((), ("0,-0.5 \n59,-0.2", "0,-0.5 \n59,-0.2"), 0),  # no 1d timeseries
+        (
+            ("0,-0.5 \n59,-0.2", "0,-0.5 \n59,-0.2"),
+            ("0,-0.5 \n59,-0.2", "0,-0.5 \n58,-0.2"),
+            0,
+        ),  # differing second element
+        (
+            ("0,-0.5 \n59,-0.2", "0,-0.5 \n59,-0.2"),
+            ("0,-0.5 \n58,-0.2", "0,-0.5 \n59,-0.2"),
+            1,
+        ),  # differing first element
+    ],
+)
+def test_first_timeseries_same_timesteps(
+    session, one_d_timeseries_tuple, two_d_timeseries_tuple, expected_invalid
+):
     for timeseries in one_d_timeseries_tuple:
         BoundaryConditions1DFactory(timeseries=timeseries)
     for timeseries in two_d_timeseries_tuple:

--- a/threedi_modelchecker/tests/test_checks_timeseries.py
+++ b/threedi_modelchecker/tests/test_checks_timeseries.py
@@ -2,6 +2,8 @@ import pytest
 from threedi_schema import models
 
 from threedi_modelchecker.checks.timeseries import (
+    FirstTimeSeriesEqualTimestepsCheck,
+    TimeSeriesEqualTimestepsCheck,
     TimeseriesExistenceCheck,
     TimeseriesIncreasingCheck,
     TimeseriesRowCheck,
@@ -10,7 +12,51 @@ from threedi_modelchecker.checks.timeseries import (
     TimeseriesValueCheck,
 )
 
-from .factories import BoundaryConditions2DFactory
+from .factories import BoundaryConditions1DFactory, BoundaryConditions2DFactory
+
+
+@pytest.mark.parametrize("check_type", ["1d","2d"])
+@pytest.mark.parametrize(
+        "timeseries_tuple,expected_invalid",
+        [
+            ((),0), # no timeseries
+            (("0,-0.5 \n59,-0.2", "0,-0.5 \n59,-0.2"),0), # same levels
+            (("0,-0.5 \n59,-0.2", "0,-0.5 \n59,-0.3"),0), # same timesteps, different levels
+            (("0,-0.5 \n59,-0.2", "0,-0.5 \n58,-0.3", "0,-0.5 \n59,-0.3"),1), # differing timestep, one error
+            (("0,-0.5 \n58,-0.2", "0,-0.5 \n59,-0.3", "0,-0.5 \n59,-0.3"),2), # differing first timestep, all other timeseries error
+        ]
+    )
+def test_timeseries_same_timesteps(session, timeseries_tuple, check_type, expected_invalid):
+    if check_type == "1d":
+        for timeseries in timeseries_tuple:
+            BoundaryConditions1DFactory(timeseries=timeseries)
+        check = TimeSeriesEqualTimestepsCheck(models.BoundaryCondition1D.timeseries)
+    elif check_type == "2d":
+        for timeseries in timeseries_tuple:
+            BoundaryConditions2DFactory(timeseries=timeseries)
+        check = TimeSeriesEqualTimestepsCheck(models.BoundaryConditions2D.timeseries)
+    invalid = check.get_invalid(session)
+    assert len(invalid) == expected_invalid
+
+
+@pytest.mark.parametrize(
+        "one_d_timeseries_tuple,two_d_timeseries_tuple,expected_invalid",
+        [
+            ((),(),0), # no timeseries
+            (("0,-0.5 \n59,-0.2", "0,-0.5 \n59,-0.2"),(),0), # no 2d timeseries
+            ((), ("0,-0.5 \n59,-0.2", "0,-0.5 \n59,-0.2"),0), # no 1d timeseries
+            (("0,-0.5 \n59,-0.2", "0,-0.5 \n59,-0.2"), ("0,-0.5 \n59,-0.2", "0,-0.5 \n58,-0.2"),0), # differing second element
+            (("0,-0.5 \n59,-0.2", "0,-0.5 \n59,-0.2"), ("0,-0.5 \n58,-0.2", "0,-0.5 \n59,-0.2"),1), # differing first element
+        ]
+    )
+def test_first_timeseries_same_timesteps(session, one_d_timeseries_tuple, two_d_timeseries_tuple, expected_invalid):
+    for timeseries in one_d_timeseries_tuple:
+        BoundaryConditions1DFactory(timeseries=timeseries)
+    for timeseries in two_d_timeseries_tuple:
+        BoundaryConditions2DFactory(timeseries=timeseries)
+    check = FirstTimeSeriesEqualTimestepsCheck()
+    invalid = check.get_invalid(session)
+    assert len(invalid) == expected_invalid
 
 
 @pytest.mark.parametrize("timeseries", ["0,-0.5", "0,-0.5 \n59,-0.5\n60,-0.5\n   "])


### PR DESCRIPTION
Adds two checks, both with error code 1206. The first check checks if the timesteps in all timeseries in a column are the same; the second check checks if the timesteps for the timeseries in the first 1D and 2D boundary conditions are the same.