### PR TITLE
Revert "243 check inflow area per connection node if larger than x m2 then a warning saying that the user should check storage in the node"

### DIFF
--- a/threedi_modelchecker/checks/other.py
+++ b/threedi_modelchecker/checks/other.py
@@ -707,33 +707,6 @@ class PumpStorageTimestepCheck(BaseCheck):
         return f"{self.column_name} will empty its storage faster than one timestep, which can cause simulation instabilities"
 
 
-class NodeInflowAreaCheck(BaseCheck):
-    """Check that total inflow area per connection node is no larger than 10,000 square metres"""
-
-    def get_invalid(self, session: Session) -> List[NamedTuple]:
-        impervious_surfaces = (
-            select(models.ImperviousSurfaceMap.connection_node_id)
-            .select_from(models.ImperviousSurfaceMap)
-            .join(
-                models.ImperviousSurface,
-                models.ImperviousSurfaceMap.impervious_surface_id
-                == models.ImperviousSurface.id,
-            )
-            .group_by(models.ImperviousSurfaceMap.connection_node_id)
-            .having(func.sum(models.ImperviousSurface.area) > 10000)
-        ).subquery()
-        return (
-            session.query(models.ConnectionNode)
-            .filter(
-                models.ConnectionNode.id == impervious_surfaces.c.connection_node_id
-            )
-            .all()
-        )
-
-    def description(self) -> str:
-        return f"{self.column_name} has a an associated inflow area larger than 10,000 m2; this might be an error."
-
-
 class BetaColumnsCheck(BaseCheck):
     """Check that no beta columns were used in the database"""
 

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -49,7 +49,6 @@ from .checks.other import (
     CrossSectionLocationCheck,
     CrossSectionSameConfigurationCheck,
     LinestringLocationCheck,
-    NodeInflowAreaCheck,
     OpenChannelsWithNestedNewton,
     PotentialBreachInterdistanceCheck,
     PotentialBreachStartEndCheck,
@@ -1833,13 +1832,6 @@ for (surface, surface_map, filters) in [
             message=f"{surface_map.__tablename__} will be ignored because it is connected to a 1D boundary condition.",
         ),
     ]
-CHECKS += [
-    NodeInflowAreaCheck(
-        error_code=613,
-        column=models.ConnectionNode.id,
-        level=CheckLevel.WARNING,
-    )
-]
 
 
 CHECKS += [

--- a/threedi_modelchecker/tests/test_checks_other.py
+++ b/threedi_modelchecker/tests/test_checks_other.py
@@ -15,7 +15,6 @@ from threedi_modelchecker.checks.other import (
     CrossSectionLocationCheck,
     CrossSectionSameConfigurationCheck,
     LinestringLocationCheck,
-    NodeInflowAreaCheck,
     OpenChannelsWithNestedNewton,
     PotentialBreachInterdistanceCheck,
     PotentialBreachStartEndCheck,
@@ -485,28 +484,6 @@ def test_pumpstation_storage_timestep(
     )
     factories.GlobalSettingsFactory(sim_time_step=time_step)
     check = PumpStorageTimestepCheck(models.Pumpstation.capacity)
-    invalid = check.get_invalid(session)
-    assert len(invalid) == expected_result
-
-
-@pytest.mark.parametrize(
-    "value,expected_result",
-    [
-        (1000, 0),  # total area = 1000 + 9000 = 10,000 <= 10,000; no error
-        (1001, 1),  # total area = 1001 + 9000 = 10,001 > 10,000; error
-    ],
-)
-def test_connection_node_inflow_area(session, value, expected_result):
-    connection_node = factories.ConnectionNodeFactory()
-    first_impervious_surface = factories.ImperviousSurfaceFactory(area=9000)
-    second_impervious_surface = factories.ImperviousSurfaceFactory(area=value)
-    factories.ImperviousSurfaceMapFactory(
-        impervious_surface=first_impervious_surface, connection_node=connection_node
-    )
-    factories.ImperviousSurfaceMapFactory(
-        impervious_surface=second_impervious_surface, connection_node=connection_node
-    )
-    check = NodeInflowAreaCheck(models.ConnectionNode.id)
     invalid = check.get_invalid(session)
     assert len(invalid) == expected_result
 


### PR DESCRIPTION
Reverts nens/threedi-modelchecker#300. I accidentally merged the wrong PR.