### PR TITLE
add checks for aggregation timesteps

### DIFF
--- a/threedi_modelchecker/checks/other.py
+++ b/threedi_modelchecker/checks/other.py
@@ -35,18 +35,19 @@ class CorrectAggregationSettingsExist(BaseCheck):
     def get_invalid(self, session: Session) -> List[NamedTuple]:
         global_settings = self.to_check(session).filter(first_setting_filter)
         correctly_defined = session.execute(
-            select(models.AggregationSettings).filter(
+            select(models.AggregationSettings)
+            .filter(
                 models.AggregationSettings.aggregation_method
                 == self.aggregation_method,
                 models.AggregationSettings.flow_variable == self.flow_variable,
-            ).filter(
-                models.AggregationSettings.global_settings_id == global_settings.subquery().c.id
+            )
+            .filter(
+                models.AggregationSettings.global_settings_id
+                == global_settings.subquery().c.id
             )
         ).all()
 
-        return (
-            global_settings.all() if len(correctly_defined) == 0 else []
-        )
+        return global_settings.all() if len(correctly_defined) == 0 else []
 
     def description(self) -> str:
         return (

--- a/threedi_modelchecker/checks/other.py
+++ b/threedi_modelchecker/checks/other.py
@@ -21,10 +21,16 @@ first_setting_filter = models.GlobalSetting.id == first_setting
 class CorrectAggregationSettings(BaseCheck):
     """Check if aggregation settings are correctly filled with aggregation_method and flow_variable as required"""
 
-    def __init__(self, aggregation_method: str, flow_variable: str, *args, **kwargs):
+    def __init__(
+        self,
+        aggregation_method: constants.AggregationMethod,
+        flow_variable: constants.FlowVariable,
+        *args,
+        **kwargs,
+    ):
         super().__init__(column=models.GlobalSetting.id, *args, **kwargs)
-        self.aggregation_method = aggregation_method
-        self.flow_variable = flow_variable
+        self.aggregation_method = aggregation_method.value
+        self.flow_variable = flow_variable.value
 
     def get_invalid(self, session: Session) -> List[NamedTuple]:
         correctly_defined = session.execute(

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -2364,12 +2364,12 @@ CHECKS += [
         message="v2_aggregation_settings.aggregation_method can only be 'current' for 'volume' or 'interception' flow_variables.",
     ),
     AllEqualCheck(
-        error_code=1151,
+        error_code=1152,
         level=CheckLevel.WARNING,
         column=models.AggregationSettings.timestep,
     ),
     QueryCheck(
-        error_code=1152,
+        error_code=1153,
         level=CheckLevel.WARNING,
         column=models.AggregationSettings.timestep,
         invalid=Query(models.AggregationSettings.timestep).filter(

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -47,6 +47,7 @@ from .checks.other import (
     ChannelManholeLevelCheck,
     ConnectionNodesDistance,
     ConnectionNodesLength,
+    CorrectAggregationSettings,
     CrossSectionLocationCheck,
     CrossSectionSameConfigurationCheck,
     ImperviousNodeInflowAreaCheck,
@@ -2408,6 +2409,28 @@ CHECKS += [
         ),
         message="v2_aggregation_settings.timestep is smaller than v2_global_settings.output_time_step",
     ),
+]
+CHECKS += [
+    CorrectAggregationSettings(
+        error_code=1154,
+        level=CheckLevel.WARNING,
+        aggregation_method=aggregation_method,
+        flow_variable=flow_variable,
+    )
+    for (aggregation_method, flow_variable) in (
+        ("cum", "pump_discharge"),
+        ("cum", "lateral_discharge"),
+        ("cum", "simple_infiltration"),
+        ("cum", "rain"),
+        ("cum", "leakage"),
+        ("current", "interception"),
+        ("cum", "discharge"),
+        ("cum_negative", "discharge"),
+        ("cum_positive", "discharge"),
+        ("current", "volume"),
+        ("cum_negative", "surface_source_sink_discharge"),
+        ("cum_positive", "surface_source_sink_discharge"),
+    )
 ]
 
 ## 12xx  SIMULATION, timeseries

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -2401,12 +2401,13 @@ CHECKS += [
         error_code=1153,
         level=CheckLevel.WARNING,
         column=models.AggregationSettings.timestep,
-        invalid=Query(models.AggregationSettings).join(
+        invalid=Query(models.AggregationSettings)
+        .join(
             models.GlobalSetting,
-            models.AggregationSettings.global_settings_id == models.GlobalSetting.id
-        ).filter(
-            first_setting_filter
-        ).filter(
+            models.AggregationSettings.global_settings_id == models.GlobalSetting.id,
+        )
+        .filter(first_setting_filter)
+        .filter(
             models.AggregationSettings.timestep < models.GlobalSetting.output_time_step
         ),
         message="v2_aggregation_settings.timestep is smaller than v2_global_settings.output_time_step",

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -2363,10 +2363,14 @@ CHECKS += [
         ),
         message="v2_aggregation_settings.aggregation_method can only be 'current' for 'volume' or 'interception' flow_variables.",
     ),
-    AllEqualCheck(error_code=1151, column=models.AggregationSettings.timestep),
+    AllEqualCheck(
+        error_code=1151,
+        level=CheckLevel.WARNING,
+        column=models.AggregationSettings.timestep,
+    ),
     QueryCheck(
         error_code=1152,
-        level=CheckLevel.INFO,
+        level=CheckLevel.WARNING,
         column=models.AggregationSettings.timestep,
         invalid=Query(models.AggregationSettings.timestep).filter(
             models.AggregationSettings.timestep

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -47,7 +47,7 @@ from .checks.other import (
     ChannelManholeLevelCheck,
     ConnectionNodesDistance,
     ConnectionNodesLength,
-    CorrectAggregationSettings,
+    CorrectAggregationSettingsExist,
     CrossSectionLocationCheck,
     CrossSectionSameConfigurationCheck,
     ImperviousNodeInflowAreaCheck,
@@ -2411,7 +2411,7 @@ CHECKS += [
     ),
 ]
 CHECKS += [
-    CorrectAggregationSettings(
+    CorrectAggregationSettingsExist(
         error_code=1154,
         level=CheckLevel.WARNING,
         aggregation_method=aggregation_method,

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -2418,18 +2418,36 @@ CHECKS += [
         flow_variable=flow_variable,
     )
     for (aggregation_method, flow_variable) in (
-        ("cum", "pump_discharge"),
-        ("cum", "lateral_discharge"),
-        ("cum", "simple_infiltration"),
-        ("cum", "rain"),
-        ("cum", "leakage"),
-        ("current", "interception"),
-        ("cum", "discharge"),
-        ("cum_negative", "discharge"),
-        ("cum_positive", "discharge"),
-        ("current", "volume"),
-        ("cum_negative", "surface_source_sink_discharge"),
-        ("cum_positive", "surface_source_sink_discharge"),
+        (constants.AggregationMethod.CUMULATIVE, constants.FlowVariable.PUMP_DISCHARGE),
+        (
+            constants.AggregationMethod.CUMULATIVE,
+            constants.FlowVariable.LATERAL_DISCHARGE,
+        ),
+        (
+            constants.AggregationMethod.CUMULATIVE,
+            constants.FlowVariable.SIMPLE_INFILTRATION,
+        ),
+        (constants.AggregationMethod.CUMULATIVE, constants.FlowVariable.RAIN),
+        (constants.AggregationMethod.CUMULATIVE, constants.FlowVariable.LEAKAGE),
+        (constants.AggregationMethod.CURRENT, constants.FlowVariable.INTERCEPTION),
+        (constants.AggregationMethod.CUMULATIVE, constants.FlowVariable.DISCHARGE),
+        (
+            constants.AggregationMethod.CUMULATIVE_NEGATIVE,
+            constants.FlowVariable.DISCHARGE,
+        ),
+        (
+            constants.AggregationMethod.CUMULATIVE_POSITIVE,
+            constants.FlowVariable.DISCHARGE,
+        ),
+        (constants.AggregationMethod.CURRENT, constants.FlowVariable.VOLUM),
+        (
+            constants.AggregationMethod.CUMULATIVE_NEGATIVE,
+            constants.FlowVariable.SURFACE_SOURCE_SINK_DISCHARGE,
+        ),
+        (
+            constants.AggregationMethod.CUMULATIVE_POSITIVE,
+            constants.FlowVariable.SURFACE_SOURCE_SINK_DISCHARGE,
+        ),
     )
 ]
 

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -2400,7 +2400,7 @@ CHECKS += [
         error_code=1153,
         level=CheckLevel.WARNING,
         column=models.AggregationSettings.timestep,
-        invalid=Query(models.AggregationSettings.timestep).filter(
+        invalid=Query(models.AggregationSettings).filter(
             models.AggregationSettings.timestep
             < Query(models.GlobalSetting.output_time_step)
             .filter(first_setting_filter)

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -2401,11 +2401,13 @@ CHECKS += [
         error_code=1153,
         level=CheckLevel.WARNING,
         column=models.AggregationSettings.timestep,
-        invalid=Query(models.AggregationSettings).filter(
-            models.AggregationSettings.timestep
-            < Query(models.GlobalSetting.output_time_step)
-            .filter(first_setting_filter)
-            .scalar_subquery()
+        invalid=Query(models.AggregationSettings).join(
+            models.GlobalSetting,
+            models.AggregationSettings.global_settings_id == models.GlobalSetting.id
+        ).filter(
+            first_setting_filter
+        ).filter(
+            models.AggregationSettings.timestep < models.GlobalSetting.output_time_step
         ),
         message="v2_aggregation_settings.timestep is smaller than v2_global_settings.output_time_step",
     ),

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -2362,7 +2362,20 @@ CHECKS += [
             )
         ),
         message="v2_aggregation_settings.aggregation_method can only be 'current' for 'volume' or 'interception' flow_variables.",
-    )
+    ),
+    AllEqualCheck(error_code=1151, column=models.AggregationSettings.timestep),
+    QueryCheck(
+        error_code=1152,
+        level=CheckLevel.INFO,
+        column=models.AggregationSettings.timestep,
+        invalid=Query(models.AggregationSettings.timestep).filter(
+            models.AggregationSettings.timestep
+            < Query(models.GlobalSetting.output_time_step)
+            .filter(first_setting_filter)
+            .scalar_subquery()
+        ),
+        message="v2_aggregation_settings.timestep is smaller than v2_global_settings.output_time_step",
+    ),
 ]
 
 ## 12xx  SIMULATION, timeseries

--- a/threedi_modelchecker/tests/test_checks_other.py
+++ b/threedi_modelchecker/tests/test_checks_other.py
@@ -12,6 +12,7 @@ from threedi_modelchecker.checks.other import (
     ChannelManholeLevelCheck,
     ConnectionNodesDistance,
     ConnectionNodesLength,
+    CorrectAggregationSettings,
     CrossSectionLocationCheck,
     CrossSectionSameConfigurationCheck,
     ImperviousNodeInflowAreaCheck,
@@ -27,6 +28,21 @@ from threedi_modelchecker.checks.other import (
 from threedi_modelchecker.model_checks import ThreediModelChecker
 
 from . import factories
+
+
+@pytest.mark.parametrize(
+    "aggregation_method,flow_variable,expected_result",
+    [
+        ("cum", "pump_discharge", 0),  # entries in aggregation settings, valid
+        ("cum", "discharge", 1),  # entries not in aggregation settings, invalid
+    ],
+)
+def test_aggregation_settings(session, aggregation_method, flow_variable, expected_result):
+    factories.GlobalSettingsFactory()
+    factories.AggregationSettingsFactory(aggregation_method=constants.AggregationMethod.CUMULATIVE, flow_variable=constants.FlowVariable.PUMP_DISCHARGE)
+    check = CorrectAggregationSettings(aggregation_method=aggregation_method, flow_variable=flow_variable)
+    invalid = check.get_invalid(session)
+    assert len(invalid) == expected_result
 
 
 def test_connection_nodes_length(session):

--- a/threedi_modelchecker/tests/test_checks_other.py
+++ b/threedi_modelchecker/tests/test_checks_other.py
@@ -33,14 +33,29 @@ from . import factories
 @pytest.mark.parametrize(
     "aggregation_method,flow_variable,expected_result",
     [
-        ("cum", "pump_discharge", 0),  # entries in aggregation settings, valid
-        ("cum", "discharge", 1),  # entries not in aggregation settings, invalid
+        (
+            constants.AggregationMethod.CUMULATIVE,
+            constants.FlowVariable.PUMP_DISCHARGE,
+            0,
+        ),  # entries in aggregation settings, valid
+        (
+            constants.AggregationMethod.CUMULATIVE,
+            constants.FlowVariable.DISCHARGE,
+            1,
+        ),  # entries not in aggregation settings, invalid
     ],
 )
-def test_aggregation_settings(session, aggregation_method, flow_variable, expected_result):
+def test_aggregation_settings(
+    session, aggregation_method, flow_variable, expected_result
+):
     factories.GlobalSettingsFactory()
-    factories.AggregationSettingsFactory(aggregation_method=constants.AggregationMethod.CUMULATIVE, flow_variable=constants.FlowVariable.PUMP_DISCHARGE)
-    check = CorrectAggregationSettings(aggregation_method=aggregation_method, flow_variable=flow_variable)
+    factories.AggregationSettingsFactory(
+        aggregation_method=constants.AggregationMethod.CUMULATIVE,
+        flow_variable=constants.FlowVariable.PUMP_DISCHARGE,
+    )
+    check = CorrectAggregationSettings(
+        aggregation_method=aggregation_method, flow_variable=flow_variable
+    )
     invalid = check.get_invalid(session)
     assert len(invalid) == expected_result
 

--- a/threedi_modelchecker/tests/test_checks_other.py
+++ b/threedi_modelchecker/tests/test_checks_other.py
@@ -12,7 +12,7 @@ from threedi_modelchecker.checks.other import (
     ChannelManholeLevelCheck,
     ConnectionNodesDistance,
     ConnectionNodesLength,
-    CorrectAggregationSettings,
+    CorrectAggregationSettingsExist,
     CrossSectionLocationCheck,
     CrossSectionSameConfigurationCheck,
     ImperviousNodeInflowAreaCheck,
@@ -48,12 +48,13 @@ from . import factories
 def test_aggregation_settings(
     session, aggregation_method, flow_variable, expected_result
 ):
-    factories.GlobalSettingsFactory()
+    factories.GlobalSettingsFactory(id=1)
     factories.AggregationSettingsFactory(
+        global_settings_id=1,
         aggregation_method=constants.AggregationMethod.CUMULATIVE,
         flow_variable=constants.FlowVariable.PUMP_DISCHARGE,
     )
-    check = CorrectAggregationSettings(
+    check = CorrectAggregationSettingsExist(
         aggregation_method=aggregation_method, flow_variable=flow_variable
     )
     invalid = check.get_invalid(session)


### PR DESCRIPTION
Check if all aggregation timesteps are the same, and if they are greater or equal to the global output timestep. Raise a warning if this is not the case.