### PR TITLE
fix incorrect units in pumpstation check 66

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of threedi-modelchecker
 2.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed incorrect units in pumpstation check 66.
 
 
 2.2.0 (2023-05-15)

--- a/threedi_modelchecker/checks/other.py
+++ b/threedi_modelchecker/checks/other.py
@@ -741,7 +741,7 @@ class PumpStorageTimestepCheck(BaseCheck):
                             )
                         )
                     )
-                    / models.Pumpstation.capacity
+                    / (models.Pumpstation.capacity / 1000)
                     < Query(models.GlobalSetting.sim_time_step)
                     .filter(first_setting_filter)
                     .scalar_subquery()

--- a/threedi_modelchecker/tests/test_checks_other.py
+++ b/threedi_modelchecker/tests/test_checks_other.py
@@ -501,9 +501,9 @@ def test_potential_breach_interdistance_other_channel(session):
 @pytest.mark.parametrize(
     "storage_area,time_step,expected_result,capacity",
     [
-        (0.64, 30, 1, 12.5),
-        (600, 30, 0, 12.5),
-        (None, 30, 0, 12.5),  # no storage --> open water --> no check
+        (0.64, 30, 1, 12500),
+        (600, 30, 0, 12500),
+        (None, 30, 0, 12500),  # no storage --> open water --> no check
         (600, 30, 0, 0),
     ],
 )


### PR DESCRIPTION
This was leading to a bug where all pumpstattions were giving an error.