### PR TITLE
Vegetation drag friction type check

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog of threedi-modelchecker
 ------------------
 
 - Ignore tiny floating-point deviations in RasterGridSizeCheck (check 798).
+- Add check 327 to make sure vegetation drag is only used if the friction type is Chezy.
 
 
 2.2.2 (2023-05-17)

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -1258,6 +1258,19 @@ CHECKS += [
 ]
 
 CHECKS += [
+    QueryCheck(
+        error_code=327,
+        column=models.GlobalSetting.vegetation_drag_settings_id,
+        invalid=Query(models.GlobalSetting).filter(
+            first_setting_filter,
+            ~is_none_or_empty(models.GlobalSetting.vegetation_drag_settings_id),
+            models.GlobalSetting.frict_type != constants.FrictionType.CHEZY.value,
+        ),
+        message="Vegetation drag can only be used in combination with friction type 1 (Chézy)",
+    )
+]
+
+CHECKS += [
     AllEqualCheck(error_code=330 + i, column=column, level=CheckLevel.WARNING)
     for i, column in enumerate(
         [


### PR DESCRIPTION
Addresses [this comment](https://github.com/nens/threedi-modelchecker/issues/291#issuecomment-1554339703) by Leendert on #291. Adds a check, 327, which errors if vegetation drag is used with any friction type other than Chézy.