### PR TITLE
fix over-eager conveyance check

### DIFF
--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -264,12 +264,21 @@ CHECKS += [
         invalid=Query(models.CrossSectionLocation)
         .join(models.CrossSectionDefinition)
         .filter(
-            models.CrossSectionDefinition.shape.not_in(
-                [
-                    constants.CrossSectionShape.TABULATED_RECTANGLE,
-                    constants.CrossSectionShape.TABULATED_TRAPEZIUM,
-                    constants.CrossSectionShape.TABULATED_YZ,
-                ]
+            (
+                models.CrossSectionDefinition.shape.not_in(
+                    [
+                        constants.CrossSectionShape.TABULATED_RECTANGLE,
+                        constants.CrossSectionShape.TABULATED_TRAPEZIUM,
+                        constants.CrossSectionShape.TABULATED_YZ,
+                    ]
+                )
+            ) & (
+                models.CrossSectionLocation.friction_type.in_(
+                    [
+                        constants.FrictionType.CHEZY_CONVEYANCE,
+                        constants.FrictionType.MANNING_CONVEYANCE
+                    ]
+                )
             )
         ),
         message=(


### PR DESCRIPTION
Unfortunately the conveyance check, 27, currently errors on all cross-section locations. This PR fixes it so it only errors on cross-section locations where friction with conveyance is incorrectly used.