### PR TITLE
Fix check 325

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog of threedi-modelchecker
 ------------------
 
 - Add info check 57 to check if pipes and culverts have closed cross-sections.
+- Fix check 325; it was giving a warning whenever an interception_file was used.
 
 
 2.4.0 (2023-09-19)

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -1306,6 +1306,7 @@ CHECKS += [
         invalid=Query(models.GlobalSetting).filter(
             first_setting_filter,
             ~is_none_or_empty(models.GlobalSetting.interception_file),
+            is_none_or_empty(models.GlobalSetting.interception_global),
         ),
         message="v2_global_settings.interception_global is recommended as fallback value when using an interception_file.",
     ),


### PR DESCRIPTION
Check 325 was giving a warning whenever an interception file was used in the global settings.