### PR TITLE
Order check descriptions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog of threedi-modelchecker
 ------------------
 
 - Order exported schematisation checks rst table to prevent unnecessarily large git diffs in threedi-docs.
+  To facilitate this, sets of strings in error messages have been converted to lists of strings.
 
 
 2.5.1 (2023-12-19)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of threedi-modelchecker
 2.5.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Order exported schematisation checks rst table to prevent unnecessarily large git diffs in threedi-docs.
 
 
 2.5.1 (2023-12-19)

--- a/threedi_modelchecker/checks/base.py
+++ b/threedi_modelchecker/checks/base.py
@@ -336,7 +336,7 @@ class EnumCheck(BaseCheck):
         return invalid_values_q.all()
 
     def description(self):
-        allowed = sorted([x.value for x in self.column.type.enum_class])
+        allowed = sorted(list({x.value for x in self.column.type.enum_class}))
         return f"{self.column_name} is not one of {allowed}"
 
 

--- a/threedi_modelchecker/checks/base.py
+++ b/threedi_modelchecker/checks/base.py
@@ -179,7 +179,7 @@ class UniqueCheck(BaseCheck):
 
     def description(self):
         if len(self.columns) > 1:
-            return f"columns {[c.name for c in self.columns]} in table {self.table.name} should be unique together"
+            return f"columns {sorted([c.name for c in self.columns])} in table {self.table.name} should be unique together"
         else:
             return f"{self.column_name} should to be unique"
 
@@ -336,7 +336,7 @@ class EnumCheck(BaseCheck):
         return invalid_values_q.all()
 
     def description(self):
-        allowed = {x.value for x in self.column.type.enum_class}
+        allowed = sorted([x.value for x in self.column.type.enum_class])
         return f"{self.column_name} is not one of {allowed}"
 
 

--- a/threedi_modelchecker/checks/base.py
+++ b/threedi_modelchecker/checks/base.py
@@ -179,7 +179,7 @@ class UniqueCheck(BaseCheck):
 
     def description(self):
         if len(self.columns) > 1:
-            return f"columns {sorted(list({c.name for c in self.columns}))} in table {self.table.name} should be unique together"
+            return f"columns {sorted({c.name for c in self.columns})} in table {self.table.name} should be unique together"
         else:
             return f"{self.column_name} should to be unique"
 
@@ -336,7 +336,7 @@ class EnumCheck(BaseCheck):
         return invalid_values_q.all()
 
     def description(self):
-        allowed = sorted(list({x.value for x in self.column.type.enum_class}))
+        allowed = sorted({x.value for x in self.column.type.enum_class})
         return f"{self.column_name} is not one of {allowed}"
 
 

--- a/threedi_modelchecker/checks/base.py
+++ b/threedi_modelchecker/checks/base.py
@@ -181,7 +181,7 @@ class UniqueCheck(BaseCheck):
         if len(self.columns) > 1:
             return f"columns {sorted({c.name for c in self.columns})} in table {self.table.name} should be unique together"
         else:
-            return f"{self.column_name} should to be unique"
+            return f"{self.column_name} should be unique"
 
 
 class AllEqualCheck(BaseCheck):

--- a/threedi_modelchecker/checks/base.py
+++ b/threedi_modelchecker/checks/base.py
@@ -179,7 +179,7 @@ class UniqueCheck(BaseCheck):
 
     def description(self):
         if len(self.columns) > 1:
-            return f"columns {sorted([c.name for c in self.columns])} in table {self.table.name} should be unique together"
+            return f"columns {sorted(list({c.name for c in self.columns}))} in table {self.table.name} should be unique together"
         else:
             return f"{self.column_name} should to be unique"
 

--- a/threedi_modelchecker/checks/cross_section_definitions.py
+++ b/threedi_modelchecker/checks/cross_section_definitions.py
@@ -15,8 +15,8 @@ class CrossSectionBaseCheck(BaseCheck):
     @property
     def shape_msg(self):
         if self.shapes is None:
-            return "{all}"
-        return sorted([x.value for x in self.shapes])
+            return ["all"]
+        return sorted(list({x.value for x in self.shapes}))
 
     def to_check(self, session):
         qs = super().to_check(session)

--- a/threedi_modelchecker/checks/cross_section_definitions.py
+++ b/threedi_modelchecker/checks/cross_section_definitions.py
@@ -16,7 +16,7 @@ class CrossSectionBaseCheck(BaseCheck):
     def shape_msg(self):
         if self.shapes is None:
             return "{all}"
-        return {x.value for x in self.shapes}
+        return sorted([x.value for x in self.shapes])
 
     def to_check(self, session):
         qs = super().to_check(session)

--- a/threedi_modelchecker/checks/cross_section_definitions.py
+++ b/threedi_modelchecker/checks/cross_section_definitions.py
@@ -16,7 +16,7 @@ class CrossSectionBaseCheck(BaseCheck):
     def shape_msg(self):
         if self.shapes is None:
             return ["all"]
-        return sorted(list({x.value for x in self.shapes}))
+        return sorted({x.value for x in self.shapes})
 
     def to_check(self, session):
         qs = super().to_check(session)

--- a/threedi_modelchecker/exporters.py
+++ b/threedi_modelchecker/exporters.py
@@ -41,6 +41,15 @@ def format_check_results(check: BaseCheck, invalid_row: NamedTuple):
 
 
 # check overview export functions
+def order_checks(checks) -> list:
+    """
+    Alphabetically order checks so that they will consistently be ordered the same.
+
+    This makes Github PR requests a lot clearer.
+    """
+    return sorted(checks, key=lambda k: (k.error_code, k.description()))
+
+
 def generate_rst_table(checks) -> str:
     "Generate an RST table to copy into the Sphinx docs with a list of checks"
     rst_table_string = ""
@@ -53,6 +62,7 @@ def generate_rst_table(checks) -> str:
         + "     - Check message"
     )
     rst_table_string += header
+    checks = order_checks(checks)
     for check in checks:
         # pad error code with leading zeroes so it is always 4 numbers
         formatted_error_code = str(check.error_code).zfill(4)
@@ -76,6 +86,8 @@ def generate_csv_table(checks) -> str:
     )
 
     writer.writeheader()
+
+    checks = order_checks(checks)
 
     for check in checks:
         writer.writerow(

--- a/threedi_modelchecker/exporters.py
+++ b/threedi_modelchecker/exporters.py
@@ -62,8 +62,7 @@ def generate_rst_table(checks) -> str:
         + "     - Check message"
     )
     rst_table_string += header
-    checks = order_checks(checks)
-    for check in checks:
+    for check in order_checks(checks):
         # pad error code with leading zeroes so it is always 4 numbers
         formatted_error_code = str(check.error_code).zfill(4)
         check_row = (

--- a/threedi_modelchecker/exporters.py
+++ b/threedi_modelchecker/exporters.py
@@ -44,6 +44,9 @@ def format_check_results(check: BaseCheck, invalid_row: NamedTuple):
 def order_checks(checks) -> list:
     """
     Alphabetically order checks so that they will consistently be ordered the same.
+    This orders first by error code, and then checks with the same error code are
+    sorted alphabetically by description. Checks are not sorted by level, because
+    in general, checks with the same error code have the same level.
 
     This makes Github PR requests a lot clearer.
     """

--- a/threedi_modelchecker/tests/test_checks_base.py
+++ b/threedi_modelchecker/tests/test_checks_base.py
@@ -171,7 +171,7 @@ def test_unique_check_multiple_description():
         )
     )
     assert unique_check.description() == (
-        "columns ['flow_variable', 'aggregation_method'] in table "
+        "columns ['aggregation_method', 'flow_variable'] in table "
         "v2_aggregation_settings should be unique together"
     )
 

--- a/threedi_modelchecker/tests/test_exporters.py
+++ b/threedi_modelchecker/tests/test_exporters.py
@@ -33,12 +33,12 @@ def test_generate_rst_table(fake_checks):
         + "   * - 0002\n"
         + "     - Warning\n"
         + "     - This sample message has code 2 and level WARNING\n"
-        + "   * - 1234\n"
-        + "     - Error\n"
-        + "     - This sample message has code 1234 and level ERROR\n"
         + "   * - 0012\n"
         + "     - Info\n"
-        + "     - This sample message has code 12 and level INFO"
+        + "     - This sample message has code 12 and level INFO\n"
+        + "   * - 1234\n"
+        + "     - Error\n"
+        + "     - This sample message has code 1234 and level ERROR"
     )
     rst_result = generate_rst_table(fake_checks)
     assert rst_result == correct_rst_result
@@ -48,8 +48,8 @@ def test_generate_csv_table(fake_checks):
     correct_csv_result = (
         '"error_code","level","description"\r\n'
         + '2,"WARNING","This sample message has code 2 and level WARNING"\r\n'
-        + '1234,"ERROR","This sample message has code 1234 and level ERROR"\r\n'
         + '12,"INFO","This sample message has code 12 and level INFO"\r\n'
+        + '1234,"ERROR","This sample message has code 1234 and level ERROR"\r\n'
     )
     csv_result = generate_csv_table(fake_checks)
     assert csv_result == correct_csv_result


### PR DESCRIPTION
This PR orders errors messages and lists within error message descriptions so that the checks overview is consistently ordered the same way. Previously, the output order was random, and therefore updating threedi-modelchecker could cause a large diff in threedi-docs.