### PR TITLE
Add checks related to vegetation and variable friction

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,9 @@ Changelog of threedi-modelchecker
 - Add error check (0191) for non-negative variable vegetation parameters
 - Add error check (0192) for disallowing fixed vegetation with Manning friction
 - Add error check (0193) for disallowing variable vegetation with Manning friction
+- Add error check (0194) for requiring that either all or none fixed vegetation parameters are defined
+- Add error check (0195) for requiring that either all or none variable vegetation parameters are defined
+
 
 
 2.5.2 (2024-01-19)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,18 +5,23 @@ Changelog of threedi-modelchecker
 2.5.3 (unreleased)
 ------------------
 
-- Add error check (0003) for CrossSectionLocation.friction_value because that check is no longer included in the factory checks.
-- Add error checks (0021, 0022) for friction value ranges
-- Add error check (0080) for absent CrossSectionLocation.friction_value and CrossSectionDefintion.friction_values for TABULATED_YZ shape
+- Add error check (0020) for CrossSectionLocation.friction_value because that check is no longer included in the factory checks.
+- Add error check (0080) for absent CrossSectionLocation.friction_value and CrossSectionDefinition.friction_values for TABULATED_YZ shape
 - Add error check (0087) for correct formatting of space separated list of values for variable friction
 - Add error check (0180) for variable friction and variable vegetation parameters only be used together with TABULATED_YZ shape
 - Add error check (0181) for correct number of values for variable friction and variable vegetation parameters
-- Add warning check (0182) for cases where fixed and variable vegetation parameters are used
-- Add warning check (0183) for cases where fixed and variable friction value(s) are used
-- Add error check (0184) for using variable friction or vegetation with open, monotonically increasing z profile
+- Add warning check (0182) for fixed and variable vegetation parameters in combination with non-conveyance friction
+- Add warning check (0183) for fixed and variable vegetation parameters in combination with conveyance friction
+- Add warning check (0184) for fixed and variable friction in combination with non-conveyance friction
+- Add warning check (0185) for fixed and variable friction in combination with conveyance friction
+- Add error check (0186) for using variable friction or vegetation with open, monotonically increasing z profile
 - Add error check (0187) for correct formatting of space separated list of variable vegetation parameters
-- Add error check (0190) for non-negative vegetation parameters
-- Add error check (0191) for disallowing vegetation with Manning friction
+- Add error check (0188) for all friction values non-negative and smaller than 1 for Manning friction
+- Add error check (0189) for all friction values non-negative for Chezy friction
+- Add error check (0190) for non-negative fixed vegetation parameters
+- Add error check (0191) for non-negative variable vegetation parameters
+- Add error check (0192) for disallowing fixed vegetation with Manning friction
+- Add error check (0193) for disallowing variable vegetation with Manning friction
 
 
 2.5.2 (2024-01-19)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,18 @@ Changelog of threedi-modelchecker
 2.5.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add error check (0003) for CrossSectionLocation.friction_value because that check is no longer included in the factory checks.
+- Add error checks (0021, 0022) for friction value ranges
+- Add error check (0080) for absent CrossSectionLocation.friction_value and CrossSectionDefintion.friction_values for TABULATED_YZ shape
+- Add error check (0087) for correct formatting of space separated list of values for variable friction
+- Add error check (0180) for variable friction and variable vegetation parameters only be used together with TABULATED_YZ shape
+- Add error check (0181) for correct number of values for variable friction and variable vegetation parameters
+- Add warning check (0182) for cases where fixed and variable vegetation parameters are used
+- Add warning check (0183) for cases where fixed and variable friction value(s) are used
+- Add error check (0184) for using variable friction or vegetation with open, monotonically increasing z profile
+- Add error check (0187) for correct formatting of space separated list of variable vegetation parameters
+- Add error check (0190) for non-negative vegetation parameters
+- Add error check (0191) for disallowing vegetation with Manning friction
 
 
 2.5.2 (2024-01-19)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@ Changelog of threedi-modelchecker
 =================================
 
 
-2.5.1 (unreleased)
+2.5.1 (2023-12-19)
 ------------------
 
 - Use Type instead of type so the library works on Python 3.8.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@ Changelog of threedi-modelchecker
 =================================
 
 
+2.5.2 (unreleased)
+------------------
+
+- Nothing changed yet.
+
+
 2.5.1 (2023-12-19)
 ------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "Click",
     "GeoAlchemy2>=0.9,!=0.11.*",
     "SQLAlchemy>=1.4",
-    "threedi-schema==0.217.*",
+    "threedi-schema==0.218.*",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "Click",
     "GeoAlchemy2>=0.9,!=0.11.*",
     "SQLAlchemy>=1.4",
-    "threedi-schema==0.218.*",
+    "threedi-schema==0.219.*",
 ]
 
 [project.optional-dependencies]

--- a/threedi_modelchecker/__init__.py
+++ b/threedi_modelchecker/__init__.py
@@ -1,5 +1,5 @@
 from .model_checks import *  # NOQA
 
 # fmt: off
-__version__ = '2.5.1'
+__version__ = '2.5.2.dev0'
 # fmt: on

--- a/threedi_modelchecker/__init__.py
+++ b/threedi_modelchecker/__init__.py
@@ -1,5 +1,5 @@
 from .model_checks import *  # NOQA
 
 # fmt: off
-__version__ = '2.5.1.dev0'
+__version__ = '2.5.1'
 # fmt: on

--- a/threedi_modelchecker/checks/cross_section_definitions.py
+++ b/threedi_modelchecker/checks/cross_section_definitions.py
@@ -678,7 +678,6 @@ class CrossSectionVariableFrictionRangeCheck(CrossSectionVariableRangeCheck):
         invalids = []
         def_table = models.CrossSectionDefinition
         loc_table = models.CrossSectionLocation
-        print(self.friction_types)
         records = set(
             self.to_check(session)
             .join(loc_table, loc_table.definition_id == def_table.id)

--- a/threedi_modelchecker/checks/cross_section_definitions.py
+++ b/threedi_modelchecker/checks/cross_section_definitions.py
@@ -607,3 +607,97 @@ class CrossSectionVariableCorrectLengthCheck(CrossSectionBaseCheck):
 
     def description(self):
         return f"{self.column.name} should contain exactly 1 value less as the profile"
+
+
+class CrossSectionVariableRangeCheck(CrossSectionBaseCheck):
+    def __init__(
+        self,
+        min_value=None,
+        max_value=None,
+        left_inclusive=True,
+        right_inclusive=True,
+        *args,
+        **kwargs,
+    ):
+        if min_value is None and max_value is None:
+            raise ValueError("Please supply at least one of {min_value, max_value}.")
+        str_parts = []
+        if min_value is None:
+            self.min_valid = lambda x: True
+        else:
+            self.min_valid = (
+                (lambda x: x >= min_value)
+                if left_inclusive
+                else (lambda x: x > min_value)
+            )
+            str_parts.append(f"{'< ' if left_inclusive else '<= '}{min_value}")
+        if max_value is None:
+            self.max_valid = lambda x: True
+        else:
+            self.max_valid = (
+                (lambda x: x <= max_value)
+                if right_inclusive
+                else (lambda x: x < max_value)
+            )
+            str_parts.append(f"{'> ' if right_inclusive else '>= '}{max_value}")
+        self.range_str = " and/or ".join(str_parts)
+        super().__init__(*args, **kwargs)
+
+    def get_invalid(self, session):
+        invalids = []
+        for record in self.to_check(session).filter(
+            (self.column != None) & (self.column != "")
+        ):
+            try:
+                values = [
+                    float(x) for x in getattr(record, self.column.name).split(" ")
+                ]
+            except ValueError:
+                invalids.append(record)
+            if not self.min_valid(min(values)):
+                invalids.append(record)
+            elif not self.max_valid(max(values)):
+                invalids.append(record)
+        return invalids
+
+    def description(self):
+        return f"some values in {self.column_name} are {self.range_str}"
+
+
+class CrossSectionVariableFrictionRangeCheck(CrossSectionVariableRangeCheck):
+    def __init__(
+        self,
+        friction_types,
+        *args,
+        **kwargs,
+    ):
+        self.friction_types = friction_types
+        super().__init__(*args, **kwargs)
+
+    def get_invalid(self, session):
+        invalids = []
+        def_table = models.CrossSectionDefinition
+        loc_table = models.CrossSectionLocation
+        print(self.friction_types)
+        records = set(
+            self.to_check(session)
+            .join(loc_table, loc_table.definition_id == def_table.id)
+            .filter(
+                loc_table.friction_type.in_(self.friction_types)
+                & def_table.friction_values.is_not(None)
+            )
+            .filter((self.column != None) & (self.column != ""))
+            .all()
+        )
+        for record in records:
+            try:
+                values = [
+                    float(x) for x in getattr(record, self.column.name).split(" ")
+                ]
+            except ValueError:
+                continue
+            if not self.min_valid(min(values)):
+                invalids.append(record)
+            elif not self.max_valid(max(values)):
+                invalids.append(record)
+        return invalids

--- a/threedi_modelchecker/checks/cross_section_definitions.py
+++ b/threedi_modelchecker/checks/cross_section_definitions.py
@@ -606,7 +606,7 @@ class CrossSectionVariableCorrectLengthCheck(CrossSectionBaseCheck):
         return invalids
 
     def description(self):
-        return f"{self.column_name} should contain exactly 1 value less as the lenght and width"
+        return f"{self.column_name} should contain 1 value for each element; len({self.column_name}) = len(width)-1"
 
 
 class CrossSectionVariableRangeCheck(CrossSectionBaseCheck):

--- a/threedi_modelchecker/checks/cross_section_definitions.py
+++ b/threedi_modelchecker/checks/cross_section_definitions.py
@@ -606,7 +606,7 @@ class CrossSectionVariableCorrectLengthCheck(CrossSectionBaseCheck):
         return invalids
 
     def description(self):
-        return f"{self.column.name} should contain exactly 1 value less as the profile"
+        return f"{self.column_name} should contain exactly 1 value less as the lenght and width"
 
 
 class CrossSectionVariableRangeCheck(CrossSectionBaseCheck):

--- a/threedi_modelchecker/checks/cross_section_definitions.py
+++ b/threedi_modelchecker/checks/cross_section_definitions.py
@@ -583,3 +583,27 @@ class CrossSectionConveyanceFrictionAdviceCheck(CrossSectionBaseCheck):
             "of friction is recommended in case there is a significant variation "
             "of the bed level (for instance, in a scenario with overflowing floodplains)."
         )
+
+
+class CrossSectionVariableCorrectLengthCheck(CrossSectionBaseCheck):
+    """Variable friction and vegetation properties should 1 value for each element; len(var_property) = len(width)-1"""
+
+    def get_invalid(self, session):
+        invalids = []
+        for record in self.to_check(session).filter(
+            (self.column.name != None) & (self.column.name != "")
+        ):
+            try:
+                # only take widths because another check already ensures len(widths) = len(heights)
+                widths = [float(x) for x in record.width.split(" ")]
+                values = [
+                    float(x) for x in getattr(record, self.column.name).split(" ")
+                ]
+            except ValueError:
+                continue  # other check catches this
+            if not (len(widths) - 1 == len(values)):
+                invalids.append(record)
+        return invalids
+
+    def description(self):
+        return f"{self.column.name} should contain exactly 1 value less as the profile"

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -172,7 +172,7 @@ CHECKS: List[BaseCheck] = []
 ## Use same error code as other null checks
 CHECKS += [
     QueryCheck(
-        error_code=3,
+        error_code=20,
         column=models.CrossSectionLocation.friction_value,
         invalid=(
             Query(models.CrossSectionLocation)
@@ -2853,15 +2853,6 @@ CHECKS += [
     for col in vegetation_parameter_columns
 ]
 CHECKS += [
-    CrossSectionFloatListCheck(
-        error_code=87,
-        column=col,
-        shapes=(constants.CrossSectionShape.TABULATED_YZ,),
-    )
-    for col in vegetation_parameter_columns
-]
-
-CHECKS += [
     QueryCheck(
         error_code=182,
         level=CheckLevel.WARNING,
@@ -2905,7 +2896,7 @@ CHECKS += [
 ]
 CHECKS += [
     QueryCheck(
-        error_code=182,
+        error_code=183,
         level=CheckLevel.WARNING,
         column=col_cross_section_location,
         invalid=Query(models.CrossSectionDefinition)
@@ -2949,39 +2940,7 @@ CHECKS += [
 ]
 CHECKS += [
     QueryCheck(
-        error_code=183,
-        level=CheckLevel.WARNING,
-        column=models.CrossSectionDefinition.friction_values,
-        invalid=(
-            Query(models.CrossSectionDefinition)
-            .join(
-                models.CrossSectionLocation,
-                models.CrossSectionLocation.definition_id
-                == models.CrossSectionDefinition.id,
-            )
-            .filter(
-                (
-                    models.CrossSectionLocation.friction_type
-                    == constants.FrictionType.CHEZY_CONVEYANCE
-                )
-                | (
-                    models.CrossSectionLocation.friction_type
-                    == constants.FrictionType.MANNING_CONVEYANCE
-                )
-            )
-            .filter(
-                models.CrossSectionDefinition.friction_values.is_not(None)
-                & models.CrossSectionLocation.friction_value.is_not(None)
-            )
-        ),
-        message=f"Both {models.CrossSectionDefinition.friction_values.table.name}.{models.CrossSectionDefinition.friction_values.name}"
-        f"and {models.CrossSectionLocation.friction_value.table.name}.{models.CrossSectionLocation.friction_value.name}"
-        f"are defined for conveyance friction. Only "
-        f"{models.CrossSectionDefinition.friction_values.table.name}.{models.CrossSectionDefinition.friction_values.name}"
-        f"will be used",
-    ),
-    QueryCheck(
-        error_code=183,
+        error_code=184,
         level=CheckLevel.WARNING,
         column=models.CrossSectionDefinition.friction_values,
         invalid=(
@@ -3012,23 +2971,55 @@ CHECKS += [
         f"{models.CrossSectionLocation.friction_value.table.name}.{models.CrossSectionLocation.friction_value.name}"
         f"will be used",
     ),
+    QueryCheck(
+        error_code=185,
+        level=CheckLevel.WARNING,
+        column=models.CrossSectionDefinition.friction_values,
+        invalid=(
+            Query(models.CrossSectionDefinition)
+            .join(
+                models.CrossSectionLocation,
+                models.CrossSectionLocation.definition_id
+                == models.CrossSectionDefinition.id,
+            )
+            .filter(
+                (
+                    models.CrossSectionLocation.friction_type
+                    == constants.FrictionType.CHEZY_CONVEYANCE
+                )
+                | (
+                    models.CrossSectionLocation.friction_type
+                    == constants.FrictionType.MANNING_CONVEYANCE
+                )
+            )
+            .filter(
+                models.CrossSectionDefinition.friction_values.is_not(None)
+                & models.CrossSectionLocation.friction_value.is_not(None)
+            )
+        ),
+        message=f"Both {models.CrossSectionDefinition.friction_values.table.name}.{models.CrossSectionDefinition.friction_values.name}"
+        f"and {models.CrossSectionLocation.friction_value.table.name}.{models.CrossSectionLocation.friction_value.name}"
+        f"are defined for conveyance friction. Only "
+        f"{models.CrossSectionDefinition.friction_values.table.name}.{models.CrossSectionDefinition.friction_values.name}"
+        f"will be used",
+    ),
 ]
 CHECKS += [
     OpenIncreasingCrossSectionVariableCheck(
-        error_code=184,
+        error_code=186,
         column=col,
     )
     for col in vegetation_parameter_columns
     + [models.CrossSectionDefinition.friction_values]
 ]
 
-## Friction values range; matches error codes for friction value checks
+## Friction values range
 CHECKS += [
     CrossSectionVariableFrictionRangeCheck(
         min_value=0,
         max_value=1,
         right_inclusive=False,
-        error_code=22,
+        error_code=188,
         column=models.CrossSectionDefinition.friction_values,
         shapes=(constants.CrossSectionShape.TABULATED_YZ,),
         friction_types=[
@@ -3040,7 +3031,7 @@ CHECKS += [
 CHECKS += [
     CrossSectionVariableFrictionRangeCheck(
         min_value=0,
-        error_code=21,
+        error_code=189,
         column=models.CrossSectionDefinition.friction_values,
         shapes=(constants.CrossSectionShape.TABULATED_YZ,),
         friction_types=[
@@ -3066,7 +3057,7 @@ CHECKS += [
 ]
 CHECKS += [
     CrossSectionVariableRangeCheck(
-        error_code=190,
+        error_code=191,
         min_value=0,
         column=col,
         shapes=(constants.CrossSectionShape.TABULATED_YZ,),
@@ -3081,7 +3072,7 @@ CHECKS += [
 
 CHECKS += [
     QueryCheck(
-        error_code=191,
+        error_code=192,
         column=col,
         invalid=Query(models.CrossSectionLocation)
         .filter(
@@ -3106,7 +3097,7 @@ CHECKS += [
 ]
 CHECKS += [
     QueryCheck(
-        error_code=191,
+        error_code=193,
         column=col,
         invalid=(
             Query(models.CrossSectionDefinition)

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -2754,6 +2754,24 @@ CHECKS += [
     )
 ]
 
+## 018x cross section parameters (continues 008x)
+CHECKS += [
+    CrossSectionFloatListCheck(
+        error_code=187,
+        column=col,
+        shapes=(
+            constants.CrossSectionShape.TABULATED_YZ,
+        ),
+    )
+    for col in [
+        models.CrossSectionDefinition.friction_values,
+        models.CrossSectionDefinition.vegetation_drag_coefficients,
+        models.CrossSectionDefinition.vegetation_heights,
+        models.CrossSectionDefinition.vegetation_stem_diameters,
+        models.CrossSectionDefinition.vegetation_stem_densities,
+    ]
+]
+
 # These checks are optional, depending on a command line argument
 beta_features_check = []
 beta_features_check += [

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -2863,23 +2863,26 @@ CHECKS += [
     QueryCheck(
         error_code=182,
         level=CheckLevel.WARNING,
-        column=col_csloc,
+        column=col_cross_section_location,
         invalid=Query(models.CrossSectionDefinition)
         .join(
             models.CrossSectionLocation,
             models.CrossSectionLocation.definition_id
             == models.CrossSectionDefinition.id,
         )
-        .filter(col_csloc.is_not(None) & col_csdef.is_not(None))
+        .filter(
+            col_cross_section_location.is_not(None)
+            & col_cross_section_definition.is_not(None)
+        )
         .filter(
             models.CrossSectionLocation.friction_type.is_(constants.FrictionType.CHEZY)
         ),
         message=(
-            f"Both {col_csloc.table.name}.{col_csloc.name} and {col_csdef.table.name}.{col_csdef.name}"
-            f" defined without conveyance; {col_csloc.table.name}.{col_csloc.name} will be used"
+            f"Both {col_cross_section_location.table.name}.{col_cross_section_location.name} and {col_cross_section_definition.table.name}.{col_cross_section_definition.name}"
+            f" defined without conveyance; {col_cross_section_location.table.name}.{col_cross_section_location.name} will be used"
         ),
     )
-    for col_csloc, col_csdef in [
+    for col_cross_section_location, col_cross_section_definition in [
         (
             models.CrossSectionLocation.vegetation_drag_coefficient,
             models.CrossSectionDefinition.vegetation_drag_coefficients,

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -2817,8 +2817,6 @@ CHECKS += [
     )
 ]
 
-# TODO: reconsider number because 01xx exists!
-# TODO add friction value / friction_values check here
 ## 018x cross section parameters (continues 008x)
 veg_par_cols = [
     models.CrossSectionDefinition.vegetation_drag_coefficients,
@@ -3014,14 +3012,13 @@ CHECKS += [
     for col in veg_par_cols + [models.CrossSectionDefinition.friction_values]
 ]
 
-## Friction values - move - give correct number
-## 9999
+## Friction values range; matches error codes for friction value checks
 CHECKS += [
     CrossSectionVariableFrictionRangeCheck(
         min_value=0,
         max_value=1,
         right_inclusive=False,
-        error_code=9999,
+        error_code=22,
         column=models.CrossSectionDefinition.friction_values,
         shapes=(constants.CrossSectionShape.TABULATED_YZ,),
         friction_types=[
@@ -3033,7 +3030,7 @@ CHECKS += [
 CHECKS += [
     CrossSectionVariableFrictionRangeCheck(
         min_value=0,
-        error_code=9999,
+        error_code=21,
         column=models.CrossSectionDefinition.friction_values,
         shapes=(constants.CrossSectionShape.TABULATED_YZ,),
         friction_types=[

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -2839,7 +2839,7 @@ CHECKS += [
             f"a {constants.CrossSectionShape.TABULATED_YZ.name} cross section shape"
         ),
     )
-    for col in veg_par_cols + models.CrossSectionDefinition.friction_values
+    for col in veg_par_cols + [models.CrossSectionDefinition.friction_values]
 ]
 CHECKS += [
     CrossSectionVariableCorrectLengthCheck(

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -2932,6 +2932,66 @@ CHECKS += [
         ),
     ]
 ]
+CHECKS += [
+    QueryCheck(
+        error_code=183,
+        level=CheckLevel.WARNING,
+        column=models.CrossSectionDefinition.friction_values,
+        invalid=(
+            Query(models.CrossSectionDefinition)
+            .join(
+                models.CrossSectionLocation,
+                models.CrossSectionLocation.definition_id
+                == models.CrossSectionDefinition.id,
+            )
+            .filter(
+                (
+                    models.CrossSectionLocation.friction_type
+                    == constants.FrictionType.CHEZY_CONVEYANCE
+                )
+                | (
+                    models.CrossSectionLocation.friction_type
+                    == constants.FrictionType.MANNING_CONVEYANCE
+                )
+            )
+            .filter(
+                models.CrossSectionDefinition.friction_values.is_not(None)
+                & models.CrossSectionLocation.friction_value.is_not(None)
+            )
+        ),
+        message="Both {friction_value} and {friction_values} are defined for conveyance friction. "
+        "Only {friction_values} will be used.",
+    ),
+    QueryCheck(
+        error_code=183,
+        level=CheckLevel.WARNING,
+        column=models.CrossSectionDefinition.friction_values,
+        invalid=(
+            Query(models.CrossSectionDefinition)
+            .join(
+                models.CrossSectionLocation,
+                models.CrossSectionLocation.definition_id
+                == models.CrossSectionDefinition.id,
+            )
+            .filter(
+                (
+                    models.CrossSectionLocation.friction_type
+                    == constants.FrictionType.CHEZY
+                )
+                | (
+                    models.CrossSectionLocation.friction_type
+                    == constants.FrictionType.MANNING
+                )
+            )
+            .filter(
+                models.CrossSectionDefinition.friction_values.is_not(None)
+                & models.CrossSectionLocation.friction_value.is_not(None)
+            )
+        ),
+        message="Both {friction_value} and {friction_values} are defined for non-conveyance friction. "
+        "Only {friction_value} will be used.",
+    ),
+]
 
 ## Friction values - move - give correct number
 ## 9999

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -706,16 +706,9 @@ CHECKS += [
 CHECKS += [
     CrossSectionFloatListCheck(
         error_code=87,
-        column=col,
+        column=models.CrossSectionDefinition.friction_values,
         shapes=(constants.CrossSectionShape.TABULATED_YZ,),
     )
-    for col in [
-        models.CrossSectionDefinition.friction_values,
-        models.CrossSectionDefinition.vegetation_drag_coefficients,
-        models.CrossSectionDefinition.vegetation_heights,
-        models.CrossSectionDefinition.vegetation_stem_diameters,
-        models.CrossSectionDefinition.vegetation_stem_densities,
-    ]
 ]
 
 ## 01xx: LEVEL CHECKS
@@ -2859,6 +2852,15 @@ CHECKS += [
     )
     for col in vegetation_parameter_columns
 ]
+CHECKS += [
+    CrossSectionFloatListCheck(
+        error_code=87,
+        column=col,
+        shapes=(constants.CrossSectionShape.TABULATED_YZ,),
+    )
+    for col in vegetation_parameter_columns
+]
+
 CHECKS += [
     QueryCheck(
         error_code=182,

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -2808,6 +2808,84 @@ CHECKS += [
     )
     for col in veg_par_cols
 ]
+CHECKS += [
+    QueryCheck(
+        error_code=188,
+        level=CheckLevel.WARNING,
+        column=col_csloc,
+        invalid=Query(models.CrossSectionDefinition)
+        .join(
+            models.CrossSectionLocation,
+            models.CrossSectionLocation.definition_id
+            == models.CrossSectionDefinition.id,
+        )
+        .filter(col_csloc.is_not(None) & col_csdef.is_not(None))
+        .filter(
+            models.CrossSectionLocation.friction_type.is_(constants.FrictionType.CHEZY)
+        ),
+        message=(
+            f"Both {col_csloc} and {col_csdef} defined without conveyane; {col_csloc} will be used"
+        ),
+    )
+    for col_csloc, col_csdef in [
+        (
+            models.CrossSectionLocation.vegetation_drag_coefficient,
+            models.CrossSectionDefinition.vegetation_drag_coefficients,
+        ),
+        (
+            models.CrossSectionLocation.vegetation_height,
+            models.CrossSectionDefinition.vegetation_heights,
+        ),
+        (
+            models.CrossSectionLocation.vegetation_stem_diameter,
+            models.CrossSectionDefinition.vegetation_stem_diameters,
+        ),
+        (
+            models.CrossSectionLocation.vegetation_stem_density,
+            models.CrossSectionDefinition.vegetation_stem_densities,
+        ),
+    ]
+]
+CHECKS += [
+    QueryCheck(
+        error_code=188,
+        level=CheckLevel.WARNING,
+        column=col_csloc,
+        invalid=Query(models.CrossSectionDefinition)
+        .join(
+            models.CrossSectionLocation,
+            models.CrossSectionLocation.definition_id
+            == models.CrossSectionDefinition.id,
+        )
+        .filter(col_csloc.is_not(None) & col_csdef.is_not(None))
+        .filter(
+            models.CrossSectionLocation.friction_type.is_(
+                constants.FrictionType.CHEZY_CONVEYANCE
+            )
+        ),
+        message=(
+            f"Both {col_csloc} and {col_csdef} defined with conveyane; {col_csdef} will be used"
+        ),
+    )
+    for col_csloc, col_csdef in [
+        (
+            models.CrossSectionLocation.vegetation_drag_coefficient,
+            models.CrossSectionDefinition.vegetation_drag_coefficients,
+        ),
+        (
+            models.CrossSectionLocation.vegetation_height,
+            models.CrossSectionDefinition.vegetation_heights,
+        ),
+        (
+            models.CrossSectionLocation.vegetation_stem_diameter,
+            models.CrossSectionDefinition.vegetation_stem_diameters,
+        ),
+        (
+            models.CrossSectionLocation.vegetation_stem_density,
+            models.CrossSectionDefinition.vegetation_stem_densities,
+        ),
+    ]
+]
 
 ## Friction values - move - give correct number
 ## 9999

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -2818,7 +2818,7 @@ CHECKS += [
 ]
 
 ## 018x cross section parameters (continues 008x)
-veg_par_cols = [
+vegetation_parameter_columns = [
     models.CrossSectionDefinition.vegetation_drag_coefficients,
     models.CrossSectionDefinition.vegetation_heights,
     models.CrossSectionDefinition.vegetation_stem_diameters,
@@ -2839,7 +2839,8 @@ CHECKS += [
             f"a {constants.CrossSectionShape.TABULATED_YZ.name} cross section shape"
         ),
     )
-    for col in veg_par_cols + [models.CrossSectionDefinition.friction_values]
+    for col in vegetation_parameter_columns
+    + [models.CrossSectionDefinition.friction_values]
 ]
 CHECKS += [
     CrossSectionVariableCorrectLengthCheck(
@@ -2848,7 +2849,7 @@ CHECKS += [
         shapes=(constants.CrossSectionShape.TABULATED_YZ,),
         filters=models.CrossSectionDefinition.height.is_not(None) & col.is_not(None),
     )
-    for col in veg_par_cols
+    for col in vegetation_parameter_columns
 ]
 CHECKS += [
     CrossSectionFloatListCheck(
@@ -2856,7 +2857,7 @@ CHECKS += [
         column=col,
         shapes=(constants.CrossSectionShape.TABULATED_YZ,),
     )
-    for col in veg_par_cols
+    for col in vegetation_parameter_columns
 ]
 CHECKS += [
     QueryCheck(
@@ -2901,25 +2902,28 @@ CHECKS += [
     QueryCheck(
         error_code=182,
         level=CheckLevel.WARNING,
-        column=col_csloc,
+        column=col_cross_section_location,
         invalid=Query(models.CrossSectionDefinition)
         .join(
             models.CrossSectionLocation,
             models.CrossSectionLocation.definition_id
             == models.CrossSectionDefinition.id,
         )
-        .filter(col_csloc.is_not(None) & col_csdef.is_not(None))
+        .filter(
+            col_cross_section_location.is_not(None)
+            & col_cross_section_definition.is_not(None)
+        )
         .filter(
             models.CrossSectionLocation.friction_type.is_(
                 constants.FrictionType.CHEZY_CONVEYANCE
             )
         ),
         message=(
-            f"Both {col_csloc.table.name}.{col_csloc.name} and {col_csdef.table.name}.{col_csdef.name}"
-            f" defined without conveyance; {col_csdef.table.name}.{col_csdef.name} will be used"
+            f"Both {col_cross_section_location.table.name}.{col_cross_section_location.name} and {col_cross_section_definition.table.name}.{col_cross_section_definition.name}"
+            f" defined without conveyance; {col_cross_section_definition.table.name}.{col_cross_section_definition.name} will be used"
         ),
     )
-    for col_csloc, col_csdef in [
+    for col_cross_section_location, col_cross_section_definition in [
         (
             models.CrossSectionLocation.vegetation_drag_coefficient,
             models.CrossSectionDefinition.vegetation_drag_coefficients,
@@ -3009,7 +3013,8 @@ CHECKS += [
         error_code=184,
         column=col,
     )
-    for col in veg_par_cols + [models.CrossSectionDefinition.friction_values]
+    for col in vegetation_parameter_columns
+    + [models.CrossSectionDefinition.friction_values]
 ]
 
 ## Friction values range; matches error codes for friction value checks

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -187,7 +187,7 @@ CHECKS += [
             )
             .filter(models.CrossSectionLocation.friction_value == None)
         ),
-        message=f"{models.CrossSectionLocation.friction_value.name} cannot be null or empty",
+        message="CrossSectionLocation.friction_value cannot be null or empty",
     )
 ]
 CHECKS += [
@@ -575,7 +575,9 @@ CHECKS += [
                 | (models.CrossSectionDefinition.friction_values == "")
             )
         ),
-        message="Either friction value or friction values must be defined for a TABULATED YZ shape",
+        message=f"Either {models.CrossSectionLocation.name}.{models.CrossSectionLocation.friction_value.name}"
+        f"or {models.CrossSectionDefinition.name}.{models.CrossSectionDefinition.friction_values.name}"
+        f"must be defined for a {constants.CrossSectionShape.TABULATED_YZ} cross section shape",
     )
 ]
 CHECKS += [
@@ -2834,7 +2836,10 @@ CHECKS += [
             != constants.CrossSectionShape.TABULATED_YZ
         )
         .filter(col.is_not(None)),
-        message=(f"{col} can only be used in combination with a TABULATED_YZ"),
+        message=(
+            f"{models.CrossSectionDefinition.name}.{col.name} can only be used in combination with "
+            f"a {constants.CrossSectionShape.TABULATED_YZ.shape} cross section shape"
+        ),
     )
     for col in veg_par_cols
 ]
@@ -2871,7 +2876,8 @@ CHECKS += [
             models.CrossSectionLocation.friction_type.is_(constants.FrictionType.CHEZY)
         ),
         message=(
-            f"Both {col_csloc} and {col_csdef} defined without conveyane; {col_csloc} will be used"
+            f"Both {col_csloc.table.name}.{col_csloc.name} and {col_csdef.table.name}.{col_csdef.name}"
+            f" defined without conveyance; {col_csloc.table.name}.{col_csloc.name} will be used"
         ),
     )
     for col_csloc, col_csdef in [
@@ -2911,7 +2917,8 @@ CHECKS += [
             )
         ),
         message=(
-            f"Both {col_csloc} and {col_csdef} defined with conveyane; {col_csdef} will be used"
+            f"Both {col_csloc.table.name}.{col_csloc.name} and {col_csdef.table.name}.{col_csdef.name}"
+            f" defined without conveyance; {col_csdef.table.name}.{col_csdef.name} will be used"
         ),
     )
     for col_csloc, col_csdef in [
@@ -2960,8 +2967,11 @@ CHECKS += [
                 & models.CrossSectionLocation.friction_value.is_not(None)
             )
         ),
-        message="Both {friction_value} and {friction_values} are defined for conveyance friction. "
-        "Only {friction_values} will be used.",
+        message=f"Both {models.CrossSectionDefinition.name}.{models.CrossSectionDefinition.friction_values.name}"
+        f"and {models.CrossSectionLocation.name}.{models.CrossSectionLocation.friction_value.name}"
+        f"are defined for conveyance friction. Only "
+        f"{models.CrossSectionDefinition.name}.{models.CrossSectionDefinition.friction_values.name}"
+        f"will be used",
     ),
     QueryCheck(
         error_code=183,
@@ -2989,8 +2999,11 @@ CHECKS += [
                 & models.CrossSectionLocation.friction_value.is_not(None)
             )
         ),
-        message="Both {friction_value} and {friction_values} are defined for non-conveyance friction. "
-        "Only {friction_value} will be used.",
+        message=f"Both {models.CrossSectionDefinition.name}.{models.CrossSectionDefinition.friction_values.name}"
+        f"and {models.CrossSectionLocation.name}.{models.CrossSectionLocation.friction_value.name}"
+        f"are defined for non-conveyance friction. Only "
+        f"{models.CrossSectionLocation.name}.{models.CrossSectionLocation.friction_value.name}"
+        f"will be used",
     ),
 ]
 CHECKS += [
@@ -3073,7 +3086,9 @@ CHECKS += [
             )
         )
         .filter(col.is_not(None)),
-        message=(f"{col} cannot be used with Manning type friction"),
+        message=(
+            f"{col.table.name}.{col.name} cannot be used with Manning type friction"
+        ),
     )
     for col in [
         models.CrossSectionLocation.vegetation_drag_coefficient,
@@ -3103,7 +3118,9 @@ CHECKS += [
                 & col.is_not(None)
             )
         ),
-        message=(f"{col} cannot be used with Manning type friction"),
+        message=(
+            f"{col.table.name}.{col.name} cannot be used with MANNING type friction"
+        ),
     )
     for col in [
         models.CrossSectionDefinition.vegetation_drag_coefficients,

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -47,6 +47,8 @@ from .checks.factories import (
     generate_unique_checks,
 )
 from .checks.other import (
+    AllPresentFixedVegetationParameters,
+    AllPresentVariableVegetationParameters,
     BetaColumnsCheck,
     BetaValuesCheck,
     BoundaryCondition1DObjectNumberCheck,
@@ -3042,18 +3044,26 @@ CHECKS += [
 ]
 
 ## 019x vegetation parameter checks
+vegetation_parameter_columns_singular = [
+    models.CrossSectionLocation.vegetation_drag_coefficient,
+    models.CrossSectionLocation.vegetation_height,
+    models.CrossSectionLocation.vegetation_stem_diameter,
+    models.CrossSectionLocation.vegetation_stem_density,
+]
+vegetation_parameter_columns_plural = [
+    models.CrossSectionDefinition.vegetation_drag_coefficients,
+    models.CrossSectionDefinition.vegetation_heights,
+    models.CrossSectionDefinition.vegetation_stem_diameters,
+    models.CrossSectionDefinition.vegetation_stem_densities,
+]
+
 CHECKS += [
     RangeCheck(
         error_code=190,
         column=col,
         min_value=0,
     )
-    for col in [
-        models.CrossSectionLocation.vegetation_drag_coefficient,
-        models.CrossSectionLocation.vegetation_height,
-        models.CrossSectionLocation.vegetation_stem_diameter,
-        models.CrossSectionLocation.vegetation_stem_density,
-    ]
+    for col in vegetation_parameter_columns_singular
 ]
 CHECKS += [
     CrossSectionVariableRangeCheck(
@@ -3062,12 +3072,7 @@ CHECKS += [
         column=col,
         shapes=(constants.CrossSectionShape.TABULATED_YZ,),
     )
-    for col in [
-        models.CrossSectionDefinition.vegetation_drag_coefficients,
-        models.CrossSectionDefinition.vegetation_heights,
-        models.CrossSectionDefinition.vegetation_stem_diameters,
-        models.CrossSectionDefinition.vegetation_stem_densities,
-    ]
+    for col in vegetation_parameter_columns_plural
 ]
 
 CHECKS += [
@@ -3088,12 +3093,7 @@ CHECKS += [
             f"{col.table.name}.{col.name} cannot be used with Manning type friction"
         ),
     )
-    for col in [
-        models.CrossSectionLocation.vegetation_drag_coefficient,
-        models.CrossSectionLocation.vegetation_height,
-        models.CrossSectionLocation.vegetation_stem_diameter,
-        models.CrossSectionLocation.vegetation_stem_density,
-    ]
+    for col in vegetation_parameter_columns_singular
 ]
 CHECKS += [
     QueryCheck(
@@ -3120,12 +3120,17 @@ CHECKS += [
             f"{col.table.name}.{col.name} cannot be used with MANNING type friction"
         ),
     )
-    for col in [
-        models.CrossSectionDefinition.vegetation_drag_coefficients,
-        models.CrossSectionDefinition.vegetation_heights,
-        models.CrossSectionDefinition.vegetation_stem_diameters,
-        models.CrossSectionDefinition.vegetation_stem_densities,
-    ]
+    for col in vegetation_parameter_columns_plural
+]
+CHECKS += [
+    AllPresentFixedVegetationParameters(
+        error_code=194,
+        column=vegetation_parameter_columns_singular[0],
+    ),
+    AllPresentVariableVegetationParameters(
+        error_code=195,
+        column=vegetation_parameter_columns_plural[0],
+    ),
 ]
 
 # These checks are optional, depending on a command line argument

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -2839,7 +2839,7 @@ CHECKS += [
             f"a {constants.CrossSectionShape.TABULATED_YZ.name} cross section shape"
         ),
     )
-    for col in veg_par_cols
+    for col in veg_par_cols + models.CrossSectionDefinition.friction_values
 ]
 CHECKS += [
     CrossSectionVariableCorrectLengthCheck(

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -29,6 +29,8 @@ from .checks.cross_section_definitions import (
     CrossSectionMinimumDiameterCheck,
     CrossSectionNullCheck,
     CrossSectionVariableCorrectLengthCheck,
+    CrossSectionVariableFrictionRangeCheck,
+    CrossSectionVariableRangeCheck,
     CrossSectionYZCoordinateCountCheck,
     CrossSectionYZHeightCheck,
     CrossSectionYZIncreasingWidthIfOpenCheck,
@@ -2782,6 +2784,7 @@ CHECKS += [
         error_code=181,
         column=col,
         shapes=(constants.CrossSectionShape.TABULATED_YZ,),
+        filters=models.CrossSectionDefinition.height.is_not(None) & col.is_not(None),
     )
     for col in par_cols
 ]
@@ -2792,6 +2795,64 @@ CHECKS += [
         shapes=(constants.CrossSectionShape.TABULATED_YZ,),
     )
     for col in par_cols
+]
+
+## Friction values - move - give correct number
+## 9999
+CHECKS += [
+    CrossSectionVariableFrictionRangeCheck(
+        min_value=0,
+        max_value=1,
+        right_inclusive=False,
+        error_code=9999,
+        column=models.CrossSectionDefinition.friction_values,
+        shapes=(constants.CrossSectionShape.TABULATED_YZ,),
+        friction_types=[
+            constants.FrictionType.MANNING.value,
+            constants.FrictionType.MANNING_CONVEYANCE.value,
+        ],
+    )
+]
+CHECKS += [
+    CrossSectionVariableFrictionRangeCheck(
+        min_value=0,
+        error_code=9999,
+        column=models.CrossSectionDefinition.friction_values,
+        shapes=(constants.CrossSectionShape.TABULATED_YZ,),
+        friction_types=[
+            constants.FrictionType.CHEZY.value,
+            constants.FrictionType.CHEZY_CONVEYANCE.value,
+        ],
+    )
+]
+
+## 019x vegetation parameter checks
+CHECKS += [
+    RangeCheck(
+        error_code=190,
+        column=col,
+        min_value=0,
+    )
+    for col in [
+        models.CrossSectionLocation.vegetation_drag_coefficient,
+        models.CrossSectionLocation.vegetation_height,
+        models.CrossSectionLocation.vegetation_stem_diameter,
+        models.CrossSectionLocation.vegetation_stem_density,
+    ]
+]
+CHECKS += [
+    CrossSectionVariableRangeCheck(
+        error_code=190,
+        min_value=0,
+        column=col,
+        shapes=(constants.CrossSectionShape.TABULATED_YZ,),
+    )
+    for col in [
+        models.CrossSectionDefinition.vegetation_drag_coefficients,
+        models.CrossSectionDefinition.vegetation_heights,
+        models.CrossSectionDefinition.vegetation_stem_diameters,
+        models.CrossSectionDefinition.vegetation_stem_densities,
+    ]
 ]
 
 

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -575,8 +575,8 @@ CHECKS += [
                 | (models.CrossSectionDefinition.friction_values == "")
             )
         ),
-        message=f"Either {models.CrossSectionLocation.name}.{models.CrossSectionLocation.friction_value.name}"
-        f"or {models.CrossSectionDefinition.name}.{models.CrossSectionDefinition.friction_values.name}"
+        message=f"Either {models.CrossSectionLocation.friction_value.table.name}.{models.CrossSectionLocation.friction_value.name}"
+        f"or {models.CrossSectionDefinition.friction_values.table.name}.{models.CrossSectionDefinition.friction_values.name}"
         f"must be defined for a {constants.CrossSectionShape.TABULATED_YZ} cross section shape",
     )
 ]
@@ -2835,8 +2835,8 @@ CHECKS += [
         )
         .filter(col.is_not(None)),
         message=(
-            f"{models.CrossSectionDefinition.name}.{col.name} can only be used in combination with "
-            f"a {constants.CrossSectionShape.TABULATED_YZ.shape} cross section shape"
+            f"{col.table.name}.{col.name} can only be used in combination with "
+            f"a {constants.CrossSectionShape.TABULATED_YZ.name} cross section shape"
         ),
     )
     for col in veg_par_cols
@@ -2965,10 +2965,10 @@ CHECKS += [
                 & models.CrossSectionLocation.friction_value.is_not(None)
             )
         ),
-        message=f"Both {models.CrossSectionDefinition.name}.{models.CrossSectionDefinition.friction_values.name}"
-        f"and {models.CrossSectionLocation.name}.{models.CrossSectionLocation.friction_value.name}"
+        message=f"Both {models.CrossSectionDefinition.friction_values.table.name}.{models.CrossSectionDefinition.friction_values.name}"
+        f"and {models.CrossSectionLocation.friction_value.table.name}.{models.CrossSectionLocation.friction_value.name}"
         f"are defined for conveyance friction. Only "
-        f"{models.CrossSectionDefinition.name}.{models.CrossSectionDefinition.friction_values.name}"
+        f"{models.CrossSectionDefinition.friction_values.table.name}.{models.CrossSectionDefinition.friction_values.name}"
         f"will be used",
     ),
     QueryCheck(
@@ -2997,10 +2997,10 @@ CHECKS += [
                 & models.CrossSectionLocation.friction_value.is_not(None)
             )
         ),
-        message=f"Both {models.CrossSectionDefinition.name}.{models.CrossSectionDefinition.friction_values.name}"
-        f"and {models.CrossSectionLocation.name}.{models.CrossSectionLocation.friction_value.name}"
+        message=f"Both {models.CrossSectionDefinition.friction_values.table.name}.{models.CrossSectionDefinition.friction_values.name}"
+        f"and {models.CrossSectionLocation.friction_value.table.name}.{models.CrossSectionLocation.friction_value.name}"
         f"are defined for non-conveyance friction. Only "
-        f"{models.CrossSectionLocation.name}.{models.CrossSectionLocation.friction_value.name}"
+        f"{models.CrossSectionLocation.friction_value.table.name}.{models.CrossSectionLocation.friction_value.name}"
         f"will be used",
     ),
 ]

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -35,6 +35,7 @@ from .checks.cross_section_definitions import (
     CrossSectionYZHeightCheck,
     CrossSectionYZIncreasingWidthIfOpenCheck,
     OpenIncreasingCrossSectionConveyanceFrictionCheck,
+    OpenIncreasingCrossSectionVariableCheck,
 )
 from .checks.factories import (
     generate_enum_checks,
@@ -2991,6 +2992,13 @@ CHECKS += [
         message="Both {friction_value} and {friction_values} are defined for non-conveyance friction. "
         "Only {friction_value} will be used.",
     ),
+]
+CHECKS += [
+    OpenIncreasingCrossSectionVariableCheck(
+        error_code=184,
+        column=col,
+    )
+    for col in veg_par_cols + [models.CrossSectionDefinition.friction_values]
 ]
 
 ## Friction values - move - give correct number

--- a/threedi_modelchecker/tests/test_checks_cross_section_definitions.py
+++ b/threedi_modelchecker/tests/test_checks_cross_section_definitions.py
@@ -12,6 +12,7 @@ from threedi_modelchecker.checks.cross_section_definitions import (
     CrossSectionIncreasingCheck,
     CrossSectionMinimumDiameterCheck,
     CrossSectionNullCheck,
+    CrossSectionVariableCorrectLengthCheck,
     CrossSectionYZCoordinateCountCheck,
     CrossSectionYZHeightCheck,
     CrossSectionYZIncreasingWidthIfOpenCheck,
@@ -683,3 +684,16 @@ def test_check_cross_section_conveyance_friction_info_message(
         expected_result = 0
     invalid_rows = check.get_invalid(session)
     assert len(invalid_rows) == expected_result
+
+
+@pytest.mark.parametrize("data, result", [["1 2", True], ["1 2 3", False]])
+def test_check_correct_length(session, data, result):
+    definition = factories.CrossSectionDefinitionFactory(
+        width="1 2 3", height="0 2 5", friction_values=data
+    )
+    factories.CrossSectionLocationFactory(definition=definition)
+    check = CrossSectionVariableCorrectLengthCheck(
+        column=models.CrossSectionDefinition.friction_values
+    )
+    invalid_rows = check.get_invalid(session)
+    assert (len(invalid_rows) == 0) == result


### PR DESCRIPTION
I added a load of checks. See detailed description below (ticket was not very clear). Note that the contents of these checks needs to be double checked by @GolnesaK or @nvolp.

Note that the tests fail because threedi-schema 0.219 hasn't been released, see https://github.com/nens/threedi-schema/pull/51.

## Added checks

The added checks involve variable friction, vegetation and variable vegetation.

### Type checks for variable properties

* table: `CrossSectionDefinition`
* columns: `friction_values`, `vegetation_drag_coefficients`, `vegetation_heights`, `vegetation_stem_diameters`, `vegetation_stem_densities`
* conditions:
  * string is space-separated
  * each element can be converted to a float
* effect: raise error

### Check column length of variable properties

* table: `CrossSectionDefinition`
* columns: `friction_values`, `vegetation_drag_coefficients`, `vegetation_heights`, `vegetation_stem_diameters`, `vegetation_stem_densities`
* conditions:
  * the number of values in each column should be exactly one less than those in `CrossSectionDefinition.width` and `CrossSectionDefinition.height`
* effect: raise error

### Range checks for variable friction and vegetation properties

#### Vegetation

* table: `CrossSectionLocation`
* columns: `vegetation_drag_coefficient`, `vegetation_height`, `vegetation_stem_diameter`, `vegetation_stem_density`
* conditions: every value is >= 0
* effect: raise error

#### Variable vegetation
* table: `CrossSectionDefinition`
* columns: `vegetation_drag_coefficients`, `vegetation_heights`, `vegetation_stem_diameters`, `vegetation_stem_densities`
* conditions: every value is >= 0
* effect: raise error

#### Variable friction
* table: `CrossSectionDefinition`
* column: `friction_values`
* conditions:
  * all values >= 0
  * all values < 1 in case of Manning friction
* effect: raise error

### Limit to open channels

* table: `CrossSectionDefinition`
* columns: `friction_values`, `vegetation_drag_coefficients`, `vegetation_heights`, `vegetation_stem_diameters`, `vegetation_stem_densities`
* condition: column is defined *and* the profile is open *and* the y coordinate is monotonically increasing
* effect: raise error

### Missing friction values

* columns: `CrossSectionDefinition.friction_values` and `CrossSectionLocation.friction_value`
* conditions:
  * `CrossSectionLocation.shape` is not `TABULED_YZ` and `CrossSectionLocation.friction_value` is defined
  * `CrossSectionLocation.shape` is `TABULED_YZ` and `CrossSectionLocation.friction_value` and/or  `CrossSectionDefinition.friction_values` is defined
* effect: raise error

### Limit variable friction and vegetation to cross section shape TABULATED_YZ

* table: `CrossSectionLocation`
* columns: `vegetation_drag_coefficient`, `vegetation_height`, `vegetation_stem_diameter`, `vegetation_stem_density`
* condition:
  * shape must be TABULATED_YZ
* effect: raise error

### Dependence friction type and vegetation

* Fixed parameters:
  * table: `CrossSectionLocation`
  * columns: `vegetation_drag_coefficient`, `vegetation_height`, `vegetation_stem_diameter`, `vegetation_stem_density`
* Variable parameters
  * table: `CrossSectionDefinition`
  * columns: `friction_values`, `vegetation_drag_coefficients`, `vegetation_heights`, `vegetation_stem_diameters`, `vegetation_stem_densities`
* condition: friction type is CHEZY or CHEZY_CONVEYANCE
* effect: raise

### Handling cases with fixed and variable parameters defined for friciton of vegetation

* non-conveyance friction: raise warning mentioning that fixed value (from `CrossSectionLocation`) is used
* conveyance friction: raise warning mentioning that variable value (from `CrossSectionDefinition`) is used


