### PR TITLE
Add checks for Chezy friction value(s) <= 1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog of threedi-modelchecker
 2.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add warning check (0030) to warn about a friction value <= 1 for Chezy friction
+- Add warning check (1801) to warn about friction values <= 1 or Chezy friction
 
 
 2.6.0 (2024-01-31)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,8 @@ Changelog of threedi-modelchecker
 2.6.1 (unreleased)
 ------------------
 
-- Add warning check (0030) to warn about a friction value <= 1 for Chezy friction
-- Add warning check (1801) to warn about friction values <= 1 or Chezy friction
+- Add warning check (1500) to warn about a friction value <= 1 for Chezy friction
+- Add warning check (1501) to warn about friction values <= 1 or Chezy friction
 
 
 2.6.0 (2024-01-31)

--- a/threedi_modelchecker/checks/cross_section_definitions.py
+++ b/threedi_modelchecker/checks/cross_section_definitions.py
@@ -616,6 +616,7 @@ class CrossSectionVariableRangeCheck(CrossSectionBaseCheck):
         max_value=None,
         left_inclusive=True,
         right_inclusive=True,
+        message=None,
         *args,
         **kwargs,
     ):
@@ -641,6 +642,7 @@ class CrossSectionVariableRangeCheck(CrossSectionBaseCheck):
             )
             str_parts.append(f"{'> ' if right_inclusive else '>= '}{max_value}")
         self.range_str = " and/or ".join(str_parts)
+        self.message = message
         super().__init__(*args, **kwargs)
 
     def get_invalid(self, session):
@@ -661,7 +663,10 @@ class CrossSectionVariableRangeCheck(CrossSectionBaseCheck):
         return invalids
 
     def description(self):
-        return f"some values in {self.column_name} are {self.range_str}"
+        if self.message is None:
+            return f"some values in {self.column_name} are {self.range_str}"
+        else:
+            return self.message
 
 
 class CrossSectionVariableFrictionRangeCheck(CrossSectionVariableRangeCheck):

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -3131,7 +3131,7 @@ CHECKS += [
     ),
 ]
 
-# (ab)use error_code 30 which is not used in 003x block
+# Checks for nonsensical Chezy friction values
 CHECKS += [
     RangeCheck(
         error_code=1500,

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -332,37 +332,6 @@ CHECKS += [
         level=CheckLevel.INFO,
     )
 ]
-# (ab)use error_code 30 which is not used in 003x block
-CHECKS += [
-    RangeCheck(
-        error_code=30,
-        level=CheckLevel.WARNING,
-        column=table.friction_value,
-        filters=table.friction_type == constants.FrictionType.CHEZY.value,
-        min_value=1,
-        message=f"{table.__tablename__}.friction_value is less than 1 while CHEZY friction is selected. This may cause nonsensical results.",
-    )
-    for table in [
-        models.CrossSectionLocation,
-        models.Culvert,
-        models.Pipe,
-    ]
-]
-CHECKS += [
-    RangeCheck(
-        error_code=30,
-        level=CheckLevel.WARNING,
-        column=table.friction_value,
-        filters=(table.friction_type == constants.FrictionType.CHEZY.value)
-        & (table.crest_type == constants.CrestType.BROAD_CRESTED.value),
-        min_value=1,
-        message=f"{table.__tablename__}.friction_value is less than 1 while CHEZY friction is selected. This may cause nonsensical results.",
-    )
-    for table in [
-        models.Orifice,
-        models.Weir,
-    ]
-]
 
 ## 003x: CALCULATION TYPE
 
@@ -3044,20 +3013,6 @@ CHECKS += [
     for col in vegetation_parameter_columns
     + [models.CrossSectionDefinition.friction_values]
 ]
-CHECKS += [
-    CrossSectionVariableFrictionRangeCheck(
-        min_value=1,
-        level=CheckLevel.WARNING,
-        error_code=1801,
-        column=models.CrossSectionDefinition.friction_values,
-        shapes=(constants.CrossSectionShape.TABULATED_YZ,),
-        friction_types=[
-            constants.FrictionType.CHEZY.value,
-            constants.FrictionType.CHEZY_CONVEYANCE.value,
-        ],
-        message="Some values in CrossSectionDefinition.friction_values are less than 1 while CHEZY friction is selected. This may cause nonsensical results.",
-    )
-]
 ## Friction values range
 CHECKS += [
     CrossSectionVariableFrictionRangeCheck(
@@ -3174,6 +3129,52 @@ CHECKS += [
         error_code=195,
         column=vegetation_parameter_columns_plural[0],
     ),
+]
+
+# (ab)use error_code 30 which is not used in 003x block
+CHECKS += [
+    RangeCheck(
+        error_code=1500,
+        level=CheckLevel.WARNING,
+        column=table.friction_value,
+        filters=table.friction_type == constants.FrictionType.CHEZY.value,
+        min_value=1,
+        message=f"{table.__tablename__}.friction_value is less than 1 while CHEZY friction is selected. This may cause nonsensical results.",
+    )
+    for table in [
+        models.CrossSectionLocation,
+        models.Culvert,
+        models.Pipe,
+    ]
+]
+CHECKS += [
+    RangeCheck(
+        error_code=1500,
+        level=CheckLevel.WARNING,
+        column=table.friction_value,
+        filters=(table.friction_type == constants.FrictionType.CHEZY.value)
+        & (table.crest_type == constants.CrestType.BROAD_CRESTED.value),
+        min_value=1,
+        message=f"{table.__tablename__}.friction_value is less than 1 while CHEZY friction is selected. This may cause nonsensical results.",
+    )
+    for table in [
+        models.Orifice,
+        models.Weir,
+    ]
+]
+CHECKS += [
+    CrossSectionVariableFrictionRangeCheck(
+        min_value=1,
+        level=CheckLevel.WARNING,
+        error_code=1501,
+        column=models.CrossSectionDefinition.friction_values,
+        shapes=(constants.CrossSectionShape.TABULATED_YZ,),
+        friction_types=[
+            constants.FrictionType.CHEZY.value,
+            constants.FrictionType.CHEZY_CONVEYANCE.value,
+        ],
+        message="Some values in CrossSectionDefinition.friction_values are less than 1 while CHEZY friction is selected. This may cause nonsensical results.",
+    )
 ]
 
 # These checks are optional, depending on a command line argument

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -332,7 +332,37 @@ CHECKS += [
         level=CheckLevel.INFO,
     )
 ]
-
+# (ab)use error_code 30 which is not used in 003x block
+CHECKS += [
+    RangeCheck(
+        error_code=30,
+        level=CheckLevel.WARNING,
+        column=table.friction_value,
+        filters=table.friction_type == constants.FrictionType.CHEZY.value,
+        min_value=1,
+        message=f"{table.__tablename__}.friction_value is less than 1 while CHEZY friction is selected. This may cause nonsensical results.",
+    )
+    for table in [
+        models.CrossSectionLocation,
+        models.Culvert,
+        models.Pipe,
+    ]
+]
+CHECKS += [
+    RangeCheck(
+        error_code=30,
+        level=CheckLevel.WARNING,
+        column=table.friction_value,
+        filters=(table.friction_type == constants.FrictionType.CHEZY.value)
+        & (table.crest_type == constants.CrestType.BROAD_CRESTED.value),
+        min_value=1,
+        message=f"{table.__tablename__}.friction_value is less than 1 while CHEZY friction is selected. This may cause nonsensical results.",
+    )
+    for table in [
+        models.Orifice,
+        models.Weir,
+    ]
+]
 
 ## 003x: CALCULATION TYPE
 
@@ -3014,7 +3044,20 @@ CHECKS += [
     for col in vegetation_parameter_columns
     + [models.CrossSectionDefinition.friction_values]
 ]
-
+CHECKS += [
+    CrossSectionVariableFrictionRangeCheck(
+        min_value=1,
+        level=CheckLevel.WARNING,
+        error_code=1801,
+        column=models.CrossSectionDefinition.friction_values,
+        shapes=(constants.CrossSectionShape.TABULATED_YZ,),
+        friction_types=[
+            constants.FrictionType.CHEZY.value,
+            constants.FrictionType.CHEZY_CONVEYANCE.value,
+        ],
+        message="Some values in CrossSectionDefinition.friction_values are less than 1 while CHEZY friction is selected. This may cause nonsensical results.",
+    )
+]
 ## Friction values range
 CHECKS += [
     CrossSectionVariableFrictionRangeCheck(


### PR DESCRIPTION
2 sets of changes:

1. Copied checks for Manning friction value >= 1 and modified it to work for Chezy friction
2. Added check for `CrossSectionDefinition.friction_values` and added optional message to `CrossSectionVariableRangeCheck` that overwrites the automatic message.

