### PR TITLE
Structure control migration fix ups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "Click",
     "GeoAlchemy2>=0.9,!=0.11.*",
     "SQLAlchemy>=1.4",
-    "threedi-schema==0.226.*"
+    "git+https://github.com/nens/threedi-schema.git@margriet_97_fixups_structure_control"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "Click",
     "GeoAlchemy2>=0.9,!=0.11.*",
     "SQLAlchemy>=1.4",
-    "git+https://github.com/nens/threedi-schema.git@margriet_97_fixups_structure_control"
+    "threedi-schema @ git+https://github.com/nens/threedi-schema.git@margriet_97_fixups_structure_control"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "Click",
     "GeoAlchemy2>=0.9,!=0.11.*",
     "SQLAlchemy>=1.4",
-    "threedi-schema @ git+https://github.com/nens/threedi-schema.git@margriet_97_fixups_structure_control"
+    "threedi-schema==0.227.*"
 ]
 
 [project.optional-dependencies]

--- a/threedi_modelchecker/checks/other.py
+++ b/threedi_modelchecker/checks/other.py
@@ -1159,3 +1159,41 @@ class ControlTableActionTableCheckDischargeCoefficients(TableStrCheck):
             f"{self.table.name}.{self.column} is not properly formatted."
             f"Expected one or more rows of: 'number, number'"
         )
+
+
+class ControlHasSingleMeasureVariable(BaseCheck):
+    def __init__(self, control_model, level=CheckLevel.ERROR, error_code=0):
+        control_type_map = {
+            models.ControlTable: "table",
+            models.ControlMemory: "memory",
+        }
+        self.control_type_name = control_type_map[control_model]
+        super().__init__(
+            column=control_model.id,
+            level=level,
+            error_code=error_code,
+        )
+
+    def get_invalid(self, session: Session) -> List[NamedTuple]:
+        invalid = []
+        for record in self.to_check(session):
+            res = (
+                session.query(models.ControlMeasureMap)
+                .filter(
+                    models.ControlMeasureMap.control_type == self.control_type_name,
+                    models.ControlMeasureMap.control_id == record.id,
+                )
+                .join(
+                    models.ControlMeasureLocation,
+                    models.ControlMeasureMap.measure_location_id
+                    == models.ControlMeasureLocation.id,
+                )
+                .with_entities(models.ControlMeasureLocation.measure_variable)
+            ).all()
+            first_measure_variable = res[0].measure_variable
+            if not all(item[0] == first_measure_variable for item in res):
+                invalid.append(record)
+        return invalid
+
+    def description(self) -> str:
+        return f"{self.table.name} is mapped to measure locations with different measure variables"

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -55,6 +55,7 @@ from .checks.other import (  # Use0DFlowCheck,
     ChannelManholeLevelCheck,
     ConnectionNodesDistance,
     ConnectionNodesLength,
+    ControlHasSingleMeasureVariable,
     CorrectAggregationSettingsExist,
     CrossSectionLocationCheck,
     CrossSectionSameConfigurationCheck,
@@ -2650,14 +2651,19 @@ CHECKS += [
 CHECKS += [
     ForeignKeyCheck(
         error_code=1228,
-        column=models.ControlMeasureMap.control_measure_location_id,
+        column=models.ControlMeasureMap.measure_location_id,
         reference_column=models.ControlMeasureLocation.id,
     )
 ]
 
+CHECKS += [
+    ControlHasSingleMeasureVariable(error_code=1229, control_model=table)
+    for table in [models.ControlTable, models.ControlMemory]
+]
+
+
 # 1230 - 1242
 not_null_cols = [
-    models.ControlMemory.measure_variable,
     models.ControlMemory.action_type,
     models.ControlMemory.action_value_1,
     models.ControlMemory.action_value_2,
@@ -2665,11 +2671,11 @@ not_null_cols = [
     models.ControlMemory.target_id,
     models.ControlTable.action_table,
     models.ControlTable.action_type,
-    models.ControlTable.measure_variable,
     models.ControlTable.target_type,
     models.ControlMeasureMap.weight,
-    models.ControlMeasureMap.control_measure_location_id,
+    models.ControlMeasureMap.measure_location_id,
     models.ControlMeasureLocation.connection_node_id,
+    models.ControlMeasureLocation.measure_variable,
 ]
 CHECKS += [
     NotNullCheck(error_code=1230 + i, column=col) for i, col in enumerate(not_null_cols)

--- a/threedi_modelchecker/tests/factories.py
+++ b/threedi_modelchecker/tests/factories.py
@@ -247,7 +247,6 @@ class ControlTableFactory(factory.alchemy.SQLAlchemyModelFactory):
     action_type = constants.ControlTableActionTypes.set_discharge_coefficients
     action_table = "0.0,-1.0 2.0\n1.0,-1.1 2.1"
     measure_operator = constants.MeasureOperators.greater_than
-    measure_variable = constants.MeasureVariables.waterlevel
     target_type = constants.StructureControlTypes.channel
     target_id = 10
     geom = "SRID=4326;POINT(-71.064544 42.28787)"
@@ -261,13 +260,29 @@ class ControlMemoryFactory(factory.alchemy.SQLAlchemyModelFactory):
     action_type = constants.ControlTableActionTypes.set_discharge_coefficients
     action_value_1 = 0.0
     action_value_2 = -1.0
-    measure_variable = constants.MeasureVariables.waterlevel
     target_type = constants.StructureControlTypes.channel
     target_id = 10
     is_inverse = False
     is_active = True
     upper_threshold = 1.0
     lower_threshold = -1.0
+    geom = "SRID=4326;POINT(-71.064544 42.28787)"
+
+
+class ControlMeasureMapFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = models.ControlMeasureMap
+        sqlalchemy_session = None
+
+    control_type = constants.MeasureVariables.waterlevel
+    geom = "SRID=4326;LINESTRING(30 10, 10 30, 40 40)"
+
+
+class ControlMeasureLocationFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = models.ControlMeasureLocation
+        sqlalchemy_session = None
+
     geom = "SRID=4326;POINT(-71.064544 42.28787)"
 
 

--- a/threedi_modelchecker/tests/test_checks_other.py
+++ b/threedi_modelchecker/tests/test_checks_other.py
@@ -14,6 +14,7 @@ from threedi_modelchecker.checks.other import (
     ChannelManholeLevelCheck,
     ConnectionNodesDistance,
     ConnectionNodesLength,
+    ControlHasSingleMeasureVariable,
     ControlTableActionTableCheckDefault,
     ControlTableActionTableCheckDischargeCoefficients,
     CorrectAggregationSettingsExist,
@@ -954,3 +955,31 @@ def test_control_table_action_table_check_discharge_coefficients(
     )
     check = ControlTableActionTableCheckDischargeCoefficients()
     assert (len(check.get_invalid(session)) == 0) == valid
+
+
+@pytest.mark.parametrize(
+    "measure_variables, valid",
+    [
+        (
+            [
+                constants.MeasureVariables.waterlevel,
+                constants.MeasureVariables.waterlevel,
+            ],
+            True,
+        ),
+        (
+            [constants.MeasureVariables.waterlevel, constants.MeasureVariables.volume],
+            False,
+        ),
+    ],
+)
+def test_control_has_single_measure_variable(session, measure_variables, valid):
+    factories.ControlTableFactory(id=1)
+    for i, measure_variable in enumerate(measure_variables, 1):
+        factories.ControlMeasureMapFactory(
+            control_id=1, measure_location_id=i, control_type="table"
+        )
+        factories.ControlMeasureLocationFactory(id=i, measure_variable=measure_variable)
+    check = ControlHasSingleMeasureVariable(control_model=models.ControlTable)
+    invalids = check.get_invalid(session)
+    assert (len(invalids) == 0) == valid


### PR DESCRIPTION
- Modify tests for changed table names
- Modify tests for removed `measure_variable` columns for `table_control` and `memory_control`
- Add test to ensure that only one type of `measure_variable` is associated to a single control