### PR TITLE
upgrade 1D

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog of threedi-modelchecker
 2.13.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Modify existing checks to work with schema changes for 1D
 
 
 2.13.0 (2024-10-14)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ dependencies = [
     "Click",
     "GeoAlchemy2>=0.9,!=0.11.*",
     "SQLAlchemy>=1.4",
-#    "threedi-schema==0.226.*"
-    "threedi-schema @ git+https://github.com/nens/threedi-schema.git@margriet_89_schema_300_1D"
+    "threedi-schema==0.228.*"
+#    "threedi-schema @ git+https://github.com/nens/threedi-schema.git@margriet_89_schema_300_1D"
 
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,7 @@ dependencies = [
     "Click",
     "GeoAlchemy2>=0.9,!=0.11.*",
     "SQLAlchemy>=1.4",
-    "threedi-schema==0.228.0.dev2"
-#    "threedi-schema @ git+https://github.com/nens/threedi-schema.git@margriet_89_schema_300_1D"
+    "threedi-schema @ git+https://github.com/nens/threedi-schema.git@margriet_89_schema_300_1D"
 
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
     "Click",
     "GeoAlchemy2>=0.9,!=0.11.*",
     "SQLAlchemy>=1.4",
-    "threedi-schema @ git+https://github.com/nens/threedi-schema.git@margriet_89_schema_300_1D"
+    "threedi-schema==0.228.0.dev1"
+#    "threedi-schema @ git+https://github.com/nens/threedi-schema.git@margriet_89_schema_300_1D"
 
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "Click",
     "GeoAlchemy2>=0.9,!=0.11.*",
     "SQLAlchemy>=1.4",
-    "threedi-schema==0.228.0.dev1"
+    "threedi-schema==0.228.0.dev2"
 #    "threedi-schema @ git+https://github.com/nens/threedi-schema.git@margriet_89_schema_300_1D"
 
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,7 @@ dependencies = [
     "Click",
     "GeoAlchemy2>=0.9,!=0.11.*",
     "SQLAlchemy>=1.4",
-    "threedi-schema==0.228.*"
-#    "threedi-schema @ git+https://github.com/nens/threedi-schema.git@margriet_89_schema_300_1D"
+    "threedi-schema @ git+https://github.com/nens/threedi-schema.git@margriet_89_schema_300_1D"
 
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,7 @@ dependencies = [
     "Click",
     "GeoAlchemy2>=0.9,!=0.11.*",
     "SQLAlchemy>=1.4",
-    "threedi-schema @ git+https://github.com/nens/threedi-schema.git@margriet_89_schema_300_1D"
-
+    "threedi-schema==0.228.*"
 ]
 
 [project.optional-dependencies]

--- a/threedi_modelchecker/__init__.py
+++ b/threedi_modelchecker/__init__.py
@@ -1,5 +1,5 @@
 from .model_checks import *  # NOQA
 
 # fmt: off
-__version__ = '2.13.1.dev0'
+__version__ = '2.14.0.dev0'
 # fmt: on

--- a/threedi_modelchecker/__init__.py
+++ b/threedi_modelchecker/__init__.py
@@ -1,5 +1,5 @@
 from .model_checks import *  # NOQA
 
 # fmt: off
-__version__ = '2.14.0.dev0'
+__version__ = '2.14.0.dev1'
 # fmt: on

--- a/threedi_modelchecker/checks/base.py
+++ b/threedi_modelchecker/checks/base.py
@@ -9,6 +9,7 @@ from threedi_schema.domain import custom_types
 
 class CheckLevel(IntEnum):
     ERROR = 40
+    FUTURE_ERROR = 39
     WARNING = 30
     INFO = 20
 

--- a/threedi_modelchecker/checks/cross_section_definitions.py
+++ b/threedi_modelchecker/checks/cross_section_definitions.py
@@ -480,66 +480,6 @@ class CrossSectionVegetationTableNotNegativeCheck(CrossSectionBaseCheck):
         return f"All values in {self.table.__tablename__}.{self.column_name} should be equal to or larger than 0"
 
 
-class CrossSectionVariableRangeCheck(CrossSectionBaseCheck):
-    def __init__(
-        self,
-        min_value=None,
-        max_value=None,
-        left_inclusive=True,
-        right_inclusive=True,
-        message=None,
-        *args,
-        **kwargs,
-    ):
-        if min_value is None and max_value is None:
-            raise ValueError("Please supply at least one of {min_value, max_value}.")
-        str_parts = []
-        if min_value is None:
-            self.min_valid = lambda x: True
-        else:
-            self.min_valid = (
-                (lambda x: x >= min_value)
-                if left_inclusive
-                else (lambda x: x > min_value)
-            )
-            str_parts.append(f"{'< ' if left_inclusive else '<= '}{min_value}")
-        if max_value is None:
-            self.max_valid = lambda x: True
-        else:
-            self.max_valid = (
-                (lambda x: x <= max_value)
-                if right_inclusive
-                else (lambda x: x < max_value)
-            )
-            str_parts.append(f"{'> ' if right_inclusive else '>= '}{max_value}")
-        self.range_str = " and/or ".join(str_parts)
-        self.message = message
-        super().__init__(*args, **kwargs)
-
-    def get_invalid(self, session):
-        invalids = []
-        for record in self.to_check(session).filter(
-            (self.column != None) & (self.column != "")
-        ):
-            try:
-                values = [
-                    float(x) for x in getattr(record, self.column.name).split(",")
-                ]
-            except ValueError:
-                invalids.append(record)
-            if not self.min_valid(min(values)):
-                invalids.append(record)
-            elif not self.max_valid(max(values)):
-                invalids.append(record)
-        return invalids
-
-    def description(self):
-        if self.message is None:
-            return f"some values in {self.column_name} are {self.range_str}"
-        else:
-            return self.message
-
-
 class CrossSectionVariableFrictionRangeCheck(CrossSectionBaseCheck):
     def __init__(
         self,

--- a/threedi_modelchecker/checks/cross_section_definitions.py
+++ b/threedi_modelchecker/checks/cross_section_definitions.py
@@ -393,7 +393,7 @@ def cross_section_configuration_tabulated(shape, widths, heights):
         elif last_width > 0:
             configuration = "open"
         else:
-            breakpoint()
+            raise
     elif shape == constants.CrossSectionShape.TABULATED_YZ:
         # without the rounding, floating-point errors occur
         max_width = round((max(widths) - min(widths)), 9)
@@ -407,7 +407,7 @@ def cross_section_configuration_tabulated(shape, widths, heights):
         else:
             configuration = "open"
     else:
-        breakpoint()
+        raise
     return max_width, max_height, configuration
 
 

--- a/threedi_modelchecker/checks/cross_section_definitions.py
+++ b/threedi_modelchecker/checks/cross_section_definitions.py
@@ -30,9 +30,6 @@ def parse_csv_table(str_data):
 class CrossSectionBaseCheck(BaseCheck):
     """Base class for all cross section definition checks."""
 
-    # use self.table instead of models.CrossSectionLocation
-    # adapt config.py
-
     def __init__(self, column, *args, **kwargs):
         self.shapes = kwargs.pop("shapes", None)
         super().__init__(column, *args, **kwargs)

--- a/threedi_modelchecker/checks/cross_section_definitions.py
+++ b/threedi_modelchecker/checks/cross_section_definitions.py
@@ -487,12 +487,13 @@ class OpenIncreasingCrossSectionConveyanceFrictionCheck(
             super()
             .to_check(session)
             .where(
+                self.table.c.cross_section_shape.isnot(None),
                 self.table.c.friction_type.in_(
                     [
                         constants.FrictionType.CHEZY_CONVEYANCE,
                         constants.FrictionType.MANNING_CONVEYANCE,
                     ]
-                )
+                ),
             )
         )
 

--- a/threedi_modelchecker/checks/cross_section_definitions.py
+++ b/threedi_modelchecker/checks/cross_section_definitions.py
@@ -22,7 +22,6 @@ def parse_csv_table(str_data):
 class CrossSectionBaseCheck(BaseCheck):
     """Base class for all cross section definition checks."""
 
-    # TODO: extend to work with all tables with cross sections
     # use self.table instead of models.CrossSectionLocation
     # adapt config.py
 
@@ -288,7 +287,6 @@ class CrossSectionYZIncreasingWidthIfOpenCheck(CrossSectionBaseCheck):
 
 
 def cross_section_configuration_for_record(record):
-    # TODO add test
     if record.cross_section_shape.is_tabulated:
         widths = parse_csv_table_col(
             record.cross_section_table, CrossSectionTableColumnIdx.width
@@ -309,9 +307,8 @@ def cross_section_configuration_for_record(record):
 
 def cross_section_configuration_not_tabulated(shape, width, height):
     """
-    Calculate maximum width, maximum heigth  and open/closed configuration for cross-sections.
-    If the heights or widths list is empty, but will be called, it is set to [] to avoid ValueErrors.
-    A different checks will error on the empty list instead so the user knows to fix it.
+    Retrieve maximum width, maximum height  and open/closed configuration for not tabulated
+    cross-sections.
     """
     if shape.is_tabulated:
         raise ValueError("cross_section_configuration cannot handle tabulated shaptes")
@@ -333,15 +330,12 @@ def cross_section_configuration_not_tabulated(shape, width, height):
 
 def cross_section_configuration_tabulated(shape, widths, heights):
     """
-    Calculate maximum width, maximum heigth  and open/closed configuration for cross-sections.
-    If the heights or widths list is empty, but will be called, it is set to [] to avoid ValueErrors.
-    A different checks will error on the empty list instead so the user knows to fix it.
+    Retrieve maximum width, maximum height  and open/closed configuration for tabulated cross-sections.
     """
     if not shape.is_tabulated:
         raise ValueError(
             "cross_section_configuration_tabulated can only handle tabulated shaptes"
         )
-    # TODO: update docstring
     if not widths:
         widths = [0]
     if not heights:

--- a/threedi_modelchecker/checks/cross_section_definitions.py
+++ b/threedi_modelchecker/checks/cross_section_definitions.py
@@ -491,7 +491,7 @@ class CrossSectionVariableRangeCheck(CrossSectionBaseCheck):
         ):
             try:
                 values = [
-                    float(x) for x in getattr(record, self.column.name).split(" ")
+                    float(x) for x in getattr(record, self.column.name).split(",")
                 ]
             except ValueError:
                 invalids.append(record)
@@ -518,32 +518,11 @@ class CrossSectionVariableFrictionRangeCheck(CrossSectionVariableRangeCheck):
         self.friction_types = friction_types
         super().__init__(*args, **kwargs)
 
-    def get_invalid(self, session):
-        invalids = []
-        records = set(
-            self.to_check(session)
-            .filter(
-                models.CrossSectionLocation.friction_type.in_(self.friction_types)
-                & models.CrossSectionLocation.cross_section_friction_values.is_not(None)
-            )
-            .filter((self.column != None) & (self.column != ""))
-            .all()
+    def to_check(self, session):
+        return super.to_check().filter(
+            models.CrossSectionLocation.friction_type.in_(self.friction_types)
+            & models.CrossSectionLocation.cross_section_friction_values.is_not(None)
         )
-        for record in records:
-            try:
-                values = [
-                    float(x) for x in getattr(record, self.column.name).split(" ")
-                ]
-            except ValueError:
-                continue
-            if not self.min_valid(min(values)):
-                invalids.append(record)
-            elif not self.max_valid(max(values)):
-                invalids.append(record)
-        return invalids
-
-    def description(self):
-        return f"some values in {self.column_name} are {self.range_str}, which is not allowed for friction type(s) {self.friction_types}"
 
 
 class OpenIncreasingCrossSectionVariableCheck(CrossSectionBaseCheck):

--- a/threedi_modelchecker/checks/cross_section_definitions.py
+++ b/threedi_modelchecker/checks/cross_section_definitions.py
@@ -393,7 +393,9 @@ def cross_section_configuration_tabulated(shape, widths, heights):
         elif last_width > 0:
             configuration = "open"
         else:
-            raise
+            raise ValueError(
+                "A tabulated rectangle or trapezium cannot have a negative last width"
+            )
     elif shape == constants.CrossSectionShape.TABULATED_YZ:
         # without the rounding, floating-point errors occur
         max_width = round((max(widths) - min(widths)), 9)
@@ -407,7 +409,10 @@ def cross_section_configuration_tabulated(shape, widths, heights):
         else:
             configuration = "open"
     else:
-        raise
+        raise ValueError(
+            "cross_section_configuration_tabulated was called for a tabulated shape other "
+            "than TABULATED_YZ, TABULATED_RECTANGLE or TABULATED_TRAPEZIUM"
+        )
     return max_width, max_height, configuration
 
 

--- a/threedi_modelchecker/checks/cross_section_definitions.py
+++ b/threedi_modelchecker/checks/cross_section_definitions.py
@@ -519,9 +519,13 @@ class CrossSectionVariableFrictionRangeCheck(CrossSectionVariableRangeCheck):
         super().__init__(*args, **kwargs)
 
     def to_check(self, session):
-        return super.to_check().filter(
-            models.CrossSectionLocation.friction_type.in_(self.friction_types)
-            & models.CrossSectionLocation.cross_section_friction_values.is_not(None)
+        return (
+            super()
+            .to_check(session)
+            .filter(
+                models.CrossSectionLocation.friction_type.in_(self.friction_types)
+                & models.CrossSectionLocation.cross_section_friction_values.is_not(None)
+            )
         )
 
 

--- a/threedi_modelchecker/checks/factories.py
+++ b/threedi_modelchecker/checks/factories.py
@@ -43,11 +43,18 @@ def generate_unique_checks(table, custom_level_map=None, **kwargs):
     return unique_checks
 
 
-def generate_not_null_checks(table, custom_level_map=None, **kwargs):
+def generate_not_null_checks(
+    table, custom_level_map=None, extra_not_null_columns=None, **kwargs
+):
     custom_level_map = custom_level_map or {}
     not_null_checks = []
+    if extra_not_null_columns is None:
+        extra_not_null_columns = []
     for column in table.columns:
-        if not column.nullable:
+        # breakpoint()
+        if not column.nullable or any(
+            col.compare(column) for col in extra_not_null_columns
+        ):
             level = get_level(table, column, custom_level_map)
             not_null_checks.append(NotNullCheck(column, level=level, **kwargs))
     return not_null_checks

--- a/threedi_modelchecker/checks/factories.py
+++ b/threedi_modelchecker/checks/factories.py
@@ -51,7 +51,6 @@ def generate_not_null_checks(
     if extra_not_null_columns is None:
         extra_not_null_columns = []
     for column in table.columns:
-        # breakpoint()
         if not column.nullable or any(
             col.compare(column) for col in extra_not_null_columns
         ):

--- a/threedi_modelchecker/checks/other.py
+++ b/threedi_modelchecker/checks/other.py
@@ -138,19 +138,18 @@ class CrossSectionSameConfigurationCheck(BaseCheck):
                 models.CrossSectionLocation.id.label("cross_section_id"),
                 models.CrossSectionLocation.channel_id,
                 models.CrossSectionLocation.cross_section_shape,
-                models.CrossSectionLocation.cross_section_width,
-                models.CrossSectionLocation.cross_section_height,
+                models.CrossSectionLocation.cross_section_table,
                 self.first_number_in_spaced_string(
-                    models.CrossSectionLocation.cross_section_width
+                    models.CrossSectionLocation.cross_section_table
                 ).label("first_width"),
                 self.first_number_in_spaced_string(
-                    models.CrossSectionLocation.cross_section_height
+                    models.CrossSectionLocation.cross_section_table
                 ).label("first_height"),
                 self.last_number_in_spaced_string(
-                    models.CrossSectionLocation.cross_section_width
+                    models.CrossSectionLocation.cross_section_table
                 ).label("last_width"),
                 self.last_number_in_spaced_string(
-                    models.CrossSectionLocation.cross_section_height
+                    models.CrossSectionLocation.cross_section_table
                 ).label("last_height"),
             )
             .select_from(models.CrossSectionLocation)

--- a/threedi_modelchecker/checks/other.py
+++ b/threedi_modelchecker/checks/other.py
@@ -444,14 +444,14 @@ class ChannelManholeLevelCheck(BaseCheck):
 
         channels_manholes_level_checked = channels_with_manholes.having(
             models.CrossSectionLocation.reference_level
-            < models.ConnectionNode.manhole_bottom_level
+            < models.ConnectionNode.bottom_level
         )
 
         return channels_manholes_level_checked.all()
 
     def description(self) -> str:
         return (
-            f"The connection_node.manhole_bottom_level at the {self.nodes_to_check} of this channel is higher than the "
+            f"The connection_node.bottom_level at the {self.nodes_to_check} of this channel is higher than the "
             "cross_section_location.reference_level closest to the manhole. This will be "
             "automatically fixed in threedigrid-builder."
         )

--- a/threedi_modelchecker/checks/other.py
+++ b/threedi_modelchecker/checks/other.py
@@ -822,16 +822,14 @@ class FeatureClosedCrossSectionCheck(BaseCheck):
         table = models.CrossSectionLocation
         table = self.column.table.c
         for record in session.execute(
-                select(
-                    table.id,
-                    table.cross_section_shape,
-                    table.cross_section_width,
-                    table.cross_section_height,
-                )
-                        .where(
-                    (table.cross_section_width != None)
-                    & (table.cross_section_width != "")
-                )
+            select(
+                table.id,
+                table.cross_section_shape,
+                table.cross_section_width,
+                table.cross_section_height,
+            ).where(
+                (table.cross_section_width != None) & (table.cross_section_width != "")
+            )
             # select(
             #     self.table.c.id,
             #     self.table.c.cross_section_shape,
@@ -853,8 +851,9 @@ class FeatureClosedCrossSectionCheck(BaseCheck):
             except ValueError:
                 continue  # other check catches this
 
-            _, _, configuration = cross_section_configuration(shape=record.cross_section_shape.value, width=widths,
-                                                              height=heights)
+            _, _, configuration = cross_section_configuration(
+                shape=record.cross_section_shape.value, width=widths, height=heights
+            )
 
             # Pipes and culverts should generally have a closed cross-section
             if configuration == "open":

--- a/threedi_modelchecker/checks/other.py
+++ b/threedi_modelchecker/checks/other.py
@@ -853,9 +853,8 @@ class FeatureClosedCrossSectionCheck(BaseCheck):
             except ValueError:
                 continue  # other check catches this
 
-            _, _, configuration = cross_section_configuration(
-                shape=record.cross_section_shape.value, heights=heights, widths=widths
-            )
+            _, _, configuration = cross_section_configuration(shape=record.cross_section_shape.value, width=widths,
+                                                              height=heights)
 
             # Pipes and culverts should generally have a closed cross-section
             if configuration == "open":

--- a/threedi_modelchecker/checks/other.py
+++ b/threedi_modelchecker/checks/other.py
@@ -454,6 +454,17 @@ class OpenChannelsWithNestedNewton(BaseCheck):
         self.table = table
 
     def get_invalid(self, session: Session) -> List[NamedTuple]:
+        definitions_in_use = self.to_check(session).filter(
+            models.CrossSectionDefinition.id.in_(
+                Query(models.CrossSectionLocation.definition_id).union_all(
+                    Query(models.Pipe.cross_section_definition_id),
+                    Query(models.Culvert.cross_section_definition_id),
+                    Query(models.Weir.cross_section_definition_id),
+                    Query(models.Orifice.cross_section_definition_id),
+                )
+            ),
+        )
+
         # closed_rectangle, circle, and egg cross-section definitions are always closed:
         closed_definitions = self.to_check(session).filter(
             self.table.cross_section_shape.shape.in_(

--- a/threedi_modelchecker/checks/other.py
+++ b/threedi_modelchecker/checks/other.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import aliased, Query, Session
 from threedi_schema.domain import constants, models
 
 from .base import BaseCheck, CheckLevel
-from .cross_section_definitions import cross_section_configuration
+from .cross_section_definitions import cross_section_configuration_not_tabulated
 from .geo_query import distance, length, transform
 
 
@@ -841,16 +841,6 @@ class FeatureClosedCrossSectionCheck(BaseCheck):
             ).where(
                 (table.cross_section_width != None) & (table.cross_section_width != "")
             )
-            # select(
-            #     self.table.c.id,
-            #     self.table.c.cross_section_shape,
-            #     self.table.c.cross_section_width,
-            #     self.table.c.cross_section_height,
-            # )
-            # .where(
-            #     (self.table.c.cross_section_width != None)
-            #     & (self.table.c.cross_section_width != "")
-            # )
         ):
             try:
                 widths = [float(x) for x in record.cross_section_width.split(" ")]
@@ -862,7 +852,7 @@ class FeatureClosedCrossSectionCheck(BaseCheck):
             except ValueError:
                 continue  # other check catches this
 
-            _, _, configuration = cross_section_configuration(
+            _, _, configuration = cross_section_configuration_not_tabulated(
                 shape=record.cross_section_shape.value, width=widths, height=heights
             )
 

--- a/threedi_modelchecker/checks/other.py
+++ b/threedi_modelchecker/checks/other.py
@@ -79,7 +79,7 @@ class CrossSectionLocationCheck(BaseCheck):
 
     def description(self):
         return (
-            f"v2_cross_section_location.geom is invalid: the cross-section location "
+            f"cross_section_location.geom is invalid: the cross-section location "
             f"should be located on the channel geometry (tolerance = {self.max_distance} m)"
         )
 
@@ -452,8 +452,8 @@ class ChannelManholeLevelCheck(BaseCheck):
 
     def description(self) -> str:
         return (
-            f"The v2_manhole.bottom_level at the {self.nodes_to_check} of this v2_channel is higher than the "
-            "v2_cross_section_location.reference_level closest to the manhole. This will be "
+            f"The connection_node.manhole_bottom_level at the {self.nodes_to_check} of this channel is higher than the "
+            "cross_section_location.reference_level closest to the manhole. This will be "
             "automatically fixed in threedigrid-builder."
         )
 

--- a/threedi_modelchecker/checks/other.py
+++ b/threedi_modelchecker/checks/other.py
@@ -1,5 +1,4 @@
 import re
-from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import List, Literal, NamedTuple
 
@@ -890,16 +889,17 @@ class BetaValuesCheck(BaseCheck):
         return f"The value you have used for {self.column_name} is still in beta; please do not use it yet."
 
 
-class AllPresent(BaseCheck, ABC):
-    """Base class to check if all or none values are present for a list of columns"""
+class AllPresentVegetationParameters(BaseCheck):
+    """Check if all or none vegetation values are defined in the CrossSectionLocation table"""
 
-    def __init__(self, columns, *args, **kwargs):
-        self.columns = columns
+    def __init__(self, *args, **kwargs):
+        self.columns = [
+            models.CrossSectionLocation.vegetation_drag_coefficient,
+            models.CrossSectionLocation.vegetation_height,
+            models.CrossSectionLocation.vegetation_stem_diameter,
+            models.CrossSectionLocation.vegetation_stem_density,
+        ]
         super().__init__(*args, **kwargs)
-
-    @abstractmethod
-    def _get_records(self, session):
-        pass
 
     def get_invalid(self, session):
         # Create filters that find all rows where all or none of the values are present
@@ -910,35 +910,7 @@ class AllPresent(BaseCheck, ABC):
             *[(col == None) | (col == "") for col in self.columns]
         )
         # Return all rows where neither all or none values are present
-        return (
-            self._get_records(session)
-            .filter(not_(filter_condition_all))
-            .filter(not_(filter_condition_none))
-            .all()
-        )
-
-    def description(self):
-        column_string = ",".join(
-            [f"{column.table.name}.{column.name}" for column in self.columns]
-        )
-        return f"All of these columns must be defined: {column_string}"
-
-
-class AllPresentFixedVegetationParameters(AllPresent):
-    """Check if all or none vegetation values are defined in the CrossSectionLocation table"""
-
-    def __init__(self, *args, **kwargs):
-        columns = [
-            models.CrossSectionLocation.vegetation_drag_coefficient,
-            models.CrossSectionLocation.vegetation_height,
-            models.CrossSectionLocation.vegetation_stem_diameter,
-            models.CrossSectionLocation.vegetation_stem_density,
-        ]
-        super().__init__(columns, *args, **kwargs)
-
-    def _get_records(self, session):
-        # Get records with valid settings for vegetation in CrossSectionLocation
-        return (
+        records = (
             session.query(models.CrossSectionLocation)
             .filter(
                 models.CrossSectionLocation.friction_type.is_(
@@ -952,36 +924,10 @@ class AllPresentFixedVegetationParameters(AllPresent):
             )
         )
 
-
-class AllPresentVariableVegetationParameters(AllPresent):
-    def __init__(self, *args, **kwargs):
-        columns = [
-            models.CrossSectionDefinition.vegetation_drag_coefficients,
-            models.CrossSectionDefinition.vegetation_heights,
-            models.CrossSectionDefinition.vegetation_stem_diameters,
-            models.CrossSectionDefinition.vegetation_stem_densities,
-        ]
-        super().__init__(columns, *args, **kwargs)
-
-    def _get_records(self, session):
-        # Get records with valid settings for vegetation in CrossSectionDefinition
         return (
-            session.query(models.CrossSectionDefinition)
-            .join(
-                models.CrossSectionLocation,
-                models.CrossSectionDefinition.id
-                == models.CrossSectionLocation.definition_id,
-            )
-            .filter(
-                models.CrossSectionLocation.friction_type.is_(
-                    constants.FrictionType.CHEZY_CONVEYANCE
-                )
-            )
-            .filter(
-                models.CrossSectionDefinition.shape.is_(
-                    constants.CrossSectionShape.TABULATED_YZ
-                )
-            )
+            records.filter(not_(filter_condition_all))
+            .filter(not_(filter_condition_none))
+            .all()
         )
 
 

--- a/threedi_modelchecker/checks/other.py
+++ b/threedi_modelchecker/checks/other.py
@@ -413,15 +413,20 @@ class ChannelManholeLevelCheck(BaseCheck):
                     )
                 ),
             )
-            .join(models.Channel, isouter=True)
+            .join(
+                models.CrossSectionLocation,
+                models.CrossSectionLocation.channel_id == models.Channel.id,
+            )
             .group_by(models.Channel.id)
         )
+
         channels_with_manholes = channels_with_cs_locations.join(
-            models.Manhole,
-            connection_node_id_col == models.Manhole.connection_node_id,
+            models.ConnectionNode, models.ConnectionNode.id == connection_node_id_col
         )
+
         channels_manholes_level_checked = channels_with_manholes.having(
-            models.CrossSectionLocation.reference_level < models.Manhole.bottom_level
+            models.CrossSectionLocation.reference_level
+            < models.ConnectionNode.manhole_bottom_level
         )
 
         return channels_manholes_level_checked.all()

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -44,11 +44,12 @@ from .checks.factories import (
     generate_type_checks,
     generate_unique_checks,
 )
-from .checks.other import (  # Use0DFlowCheck,,; ChannelManholeLevelCheck,; ,; ,; OpenChannelsWithNestedNewton,,; CrossSectionSameConfigurationCheck,
+from .checks.other import (  # Use0DFlowCheck,,;,; ,; ,; OpenChannelsWithNestedNewton,,; CrossSectionSameConfigurationCheck,
     AllPresentFixedVegetationParameters,
     BetaColumnsCheck,
     BetaValuesCheck,
     BoundaryCondition1DObjectNumberCheck,
+    ChannelManholeLevelCheck,
     ConnectionNodesDistance,
     ConnectionNodesLength,
     CorrectAggregationSettingsExist,
@@ -812,14 +813,14 @@ CHECKS += [
     )
     for table in [models.Weir, models.Orifice]
 ]
-# CHECKS += [
-#     ChannelManholeLevelCheck(
-#         level=CheckLevel.INFO, nodes_to_check="start", error_code=109
-#     ),
-#     ChannelManholeLevelCheck(
-#         level=CheckLevel.INFO, nodes_to_check="end", error_code=110
-#     ),
-# ]
+CHECKS += [
+    ChannelManholeLevelCheck(
+        level=CheckLevel.INFO, nodes_to_check="start", error_code=109
+    ),
+    ChannelManholeLevelCheck(
+        level=CheckLevel.INFO, nodes_to_check="end", error_code=110
+    ),
+]
 
 ## Linked channels
 CHECKS += [

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -29,6 +29,7 @@ from .checks.cross_section_definitions import (  # CrossSectionVariableRangeChec
     CrossSectionTableCheck,
     CrossSectionVariableCorrectLengthCheck,
     CrossSectionVariableFrictionRangeCheck,
+    CrossSectionVegetationTableNotNegativeCheck,
     CrossSectionYZCoordinateCountCheck,
     CrossSectionYZHeightCheck,
     CrossSectionYZIncreasingWidthIfOpenCheck,
@@ -2957,6 +2958,14 @@ CHECKS += [
 ]
 # TODO: replace with check for cross_section_friction_values and cross_section_vegetation_table
 # TODO: add CrossSectionVariableRangeCheck for cross_section_vegetation_table
+
+CHECKS += [
+    CrossSectionVegetationTableNotNegativeCheck(
+        error_code=191,
+        column=models.CrossSectionLocation.cross_section_vegetation_table,
+        shapes=(constants.CrossSectionShape.TABULATED_YZ,),
+    )
+]
 
 CHECKS += [
     QueryCheck(

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -35,6 +35,7 @@ from .checks.cross_section_definitions import (
     CrossSectionYZHeightCheck,
     CrossSectionYZIncreasingWidthIfOpenCheck,
     OpenIncreasingCrossSectionConveyanceFrictionCheck,
+    OpenIncreasingCrossSectionConveyanceFrictionCheckWithMaterial,
     OpenIncreasingCrossSectionVariableCheck,
 )
 from .checks.factories import (
@@ -330,8 +331,14 @@ CHECKS += [
     )
 ]
 CHECKS += [
-    OpenIncreasingCrossSectionConveyanceFrictionCheck(error_code=28, column=table.id)
-    for table in cross_section_tables
+    OpenIncreasingCrossSectionConveyanceFrictionCheckWithMaterial(
+        error_code=28, column=table.id
+    )
+    for table in [models.Pipe, models.Weir, models.Orifice, models.Culvert]
+] + [
+    OpenIncreasingCrossSectionConveyanceFrictionCheck(
+        error_code=28, column=models.CrossSectionLocation.id
+    )
 ]
 
 

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -379,6 +379,7 @@ CHECKS += [
     for table in cross_section_tables
 ]
 
+# TODO: run for all tables with cross sections (?)
 CHECKS += [
     CrossSectionLocationCheck(
         level=CheckLevel.WARNING, max_distance=TOLERANCE_M, error_code=52

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -3082,24 +3082,6 @@ vegetation_parameter_columns_singular = [
     models.CrossSectionLocation.vegetation_stem_diameter,
     models.CrossSectionLocation.vegetation_stem_density,
 ]
-#
-# CHECKS += [
-#     QueryCheck(
-#         error_code=190,
-#         column=col,
-#         invalid=(
-#             Query(models.CrossSectionLocation)
-#             .filter(
-#                 models.CrossSectionLocation.cross_section_shape != constants.CrossSectionShape.TABULATED_YZ)
-#             .filter(col is not None)
-#         )
-#         message=(
-#             f"{col.table.name}.{col.name} cannot be used with Manning type friction"
-#         )
-#     )
-#     for col in vegetation_parameter_columns_singular
-# ]
-
 
 CHECKS += [
     RangeCheck(

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -421,7 +421,7 @@ CHECKS += [
 CHECKS += [
     QueryCheck(
         error_code=45,
-        level=CheckLevel.ERROR,
+        level=CheckLevel.FUTURE_ERROR,
         column=models.ConnectionNode.id,
         invalid=Query(models.ConnectionNode)
         .filter(
@@ -446,7 +446,8 @@ CHECKS += [
             ),
         ),
         message="connection_node.storage_area should be defined and greater than 0 if the connection nodes "
-        "has no connections to channels, culverts, pipes, weirs, or orifices0",
+        "has no connections to channels, culverts, pipes, weirs, or orifices0. "
+        "From September 2025 onwards, this will be an ERROR.",
     )
 ]
 
@@ -479,7 +480,7 @@ CHECKS += [
 CHECKS += [
     QueryCheck(
         error_code=47,
-        level=CheckLevel.ERROR,
+        level=CheckLevel.FUTURE_ERROR,
         column=models.ConnectionNode.id,
         invalid=Query(models.ConnectionNode)
         .filter(
@@ -518,7 +519,8 @@ CHECKS += [
         ),
         message=(
             "connection_node.storage_area for a node that is connected to a weir or an orifice, "
-            "and that has exchange type CONNECTED or ISOLATED should be defined and greater than 0"
+            "and that has exchange type CONNECTED or ISOLATED should be defined and greater than 0. "
+            "From September 2025 onwards, this will be an ERROR."
         ),
     )
 ]

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -233,6 +233,12 @@ CHECKS += [
 ]
 CHECKS += [
     NotNullCheck(
+        error_code=24, column=table.friction_value, filters=table.material_id.is_(None)
+    )
+    for table in [models.Culvert, models.Pipe]
+]
+CHECKS += [
+    NotNullCheck(
         error_code=25,
         column=table.friction_type,
         filters=(
@@ -242,6 +248,16 @@ CHECKS += [
     )
     for table in [models.Orifice, models.Weir]
 ]
+CHECKS += [
+    NotNullCheck(
+        error_code=25,
+        column=table.friction_type,
+        filters=table.material_id.is_(None),
+    )
+    for table in [models.Culvert, models.Pipe]
+]
+
+
 # Friction with conveyance should raise an error when used
 # on a column other than models.CrossSectionLocation
 
@@ -317,6 +333,7 @@ CHECKS += [
     OpenIncreasingCrossSectionConveyanceFrictionCheck(error_code=28, column=table.id)
     for table in cross_section_tables
 ]
+
 
 ## 003x: CALCULATION TYPE
 
@@ -3367,8 +3384,6 @@ not_null_columns = [
     models.CrossSectionLocation.reference_level,
     models.Culvert.connection_node_id_start,
     models.Culvert.connection_node_id_end,
-    models.Culvert.friction_type,
-    models.Culvert.friction_value,
     models.Culvert.invert_level_start,
     models.Culvert.invert_level_end,
     models.Orifice.connection_node_id_start,
@@ -3378,8 +3393,6 @@ not_null_columns = [
     models.Pipe.connection_node_id_start,
     models.Pipe.connection_node_id_end,
     models.Pipe.exchange_type,
-    models.Pipe.friction_type,
-    models.Pipe.friction_value,
     models.Pipe.invert_level_end,
     models.Pipe.invert_level_start,
     models.Pump.connection_node_id,

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -260,7 +260,6 @@ CHECKS += [
 ]
 # Friction with conveyance should only be used on
 # tabulated rectangle, tabulated trapezium, or tabulated yz shapes
-# TODO: fix
 CHECKS += [
     QueryCheck(
         error_code=27,
@@ -293,7 +292,6 @@ CHECKS += [
         ),
     )
 ]
-# TODO: fix
 CHECKS += [
     OpenIncreasingCrossSectionConveyanceFrictionCheck(error_code=28, column=table.id)
     for table in cross_section_tables
@@ -382,7 +380,6 @@ CHECKS += [
     for table in cross_section_tables
 ]
 
-# TODO: run for all tables with cross sections (?)
 CHECKS += [
     CrossSectionLocationCheck(
         level=CheckLevel.WARNING, max_distance=TOLERANCE_M, error_code=52
@@ -397,7 +394,6 @@ CHECKS += [
         ),
         message="v2_cross_section_location.bank_level will be ignored if it is below the reference_level",
     ),
-    # TODO fix
     QueryCheck(
         error_code=55,
         column=models.Channel.id,
@@ -409,14 +405,13 @@ CHECKS += [
         .filter(models.CrossSectionLocation.channel_id == None),
         message="v2_channel has no cross section locations",
     ),
-    # TODO fix
     CrossSectionSameConfigurationCheck(
         error_code=56,
         level=CheckLevel.ERROR,
         column=models.Channel.id,
     ),
 ]
-# TODO: fix
+
 CHECKS += [
     FeatureClosedCrossSectionCheck(
         error_code=57, level=CheckLevel.INFO, column=table.id
@@ -425,7 +420,6 @@ CHECKS += [
 ]
 
 ## 006x: PUMPSTATIONS
-# TODO: fix
 CHECKS += [
     QueryCheck(
         error_code=61,
@@ -555,7 +549,6 @@ CHECKS += [
 ]
 
 ## 008x: CROSS SECTION DEFINITIONS
-# TODO: fix
 CHECKS += [
     QueryCheck(
         error_code=80,
@@ -698,7 +691,6 @@ CHECKS += [
 ]
 
 ## 01xx: LEVEL CHECKS
-# TODO: fix -> moved to ConnectionNode
 CHECKS += [
     QueryCheck(
         level=CheckLevel.WARNING,
@@ -892,7 +884,6 @@ CHECKS += [
 
 
 ## 025x: Connectivity
-# TODO: fix -> moved to ConnectionNode
 
 CHECKS += [
     QueryCheck(
@@ -981,7 +972,6 @@ CHECKS += [
         message="a pump cannot be connected to itself (pump.connection_node_id must not equal the corresponding pump_map.connection_node_id_end)",
     )
 ]
-# TODO: add check to ensure models.PumpMap.connection_node_id_end != models.Pump.connection_node_id
 CHECKS += [
     QueryCheck(
         error_code=255,
@@ -994,7 +984,6 @@ CHECKS += [
         message="a pump cannot be connected to itself (pump.connection_node_id must not equal pumpmap.connection_node_id_end)",
     )
 ]
-# TODO: fix -> moved to ConnectionNode
 CHECKS += [
     QueryCheck(
         error_code=254,
@@ -1760,7 +1749,6 @@ CHECKS += [
         ),
         message="groundwater.groundwater_hydraulic_conductivity is recommended as fallback value when using a groundwater_hydraulic_conductivity_file.",
     ),
-    # TODO: fix -> moved to ConnectionNode
     RangeCheck(
         error_code=429,
         column=models.ConnectionNode.exchange_thickness,
@@ -2089,7 +2077,6 @@ CHECKS += [
         error_code=700, level=CheckLevel.WARNING, column=models.ModelSettings.dem_file
     )
 ]
-# TODO: check this check
 CHECKS += [
     RasterExistsCheck(
         error_code=701 + i,
@@ -2755,7 +2742,6 @@ CHECKS += [
 
 
 ## 018x cross section parameters (continues 008x)
-# TODO: fix
 CHECKS += [
     QueryCheck(
         error_code=180,
@@ -2776,10 +2762,7 @@ CHECKS += [
         models.CrossSectionLocation.cross_section_vegetation_table,
     ]
 ]
-# TODO: fix
-# TODO: replace with check for cross_section_friction_values and cross_section_vegetation_table
-# TODO: add check for cross_section_vegetation_table
-# TODO add checks for pipe, etc
+
 CHECKS += [
     CrossSectionVariableCorrectLengthCheck(
         error_code=181,
@@ -2790,7 +2773,6 @@ CHECKS += [
     )
 ]
 
-# TODO: fix
 CHECKS += [
     QueryCheck(
         error_code=182,
@@ -2816,7 +2798,7 @@ CHECKS += [
         models.CrossSectionLocation.vegetation_stem_density,
     ]
 ]
-# TODO: fix
+
 CHECKS += [
     QueryCheck(
         error_code=183,
@@ -2844,8 +2826,7 @@ CHECKS += [
         models.CrossSectionLocation.vegetation_stem_density,
     ]
 ]
-# TODO: fix
-#
+
 CHECKS += [
     QueryCheck(
         error_code=184,
@@ -2904,7 +2885,6 @@ CHECKS += [
     for table in cross_section_tables
 ]
 ## Friction values range
-# TODO add checks for pipe, etc
 CHECKS += [
     CrossSectionVariableFrictionRangeCheck(
         min_value=0,
@@ -2919,7 +2899,6 @@ CHECKS += [
         ],
     )
 ]
-# TODO add checks for pipe, etc
 CHECKS += [
     CrossSectionVariableFrictionRangeCheck(
         min_value=0,
@@ -2940,13 +2919,7 @@ vegetation_parameter_columns_singular = [
     models.CrossSectionLocation.vegetation_stem_diameter,
     models.CrossSectionLocation.vegetation_stem_density,
 ]
-# TODO: fix this
-# vegetation_parameter_columns_plural = [
-#     models.CrossSectionLocation.vegetation_drag_coefficients,
-#     models.CrossSectionLocation.vegetation_heights,
-#     models.CrossSectionLocation.vegetation_stem_diameters,
-#     models.CrossSectionLocation.vegetation_stem_densities,
-# ]
+
 
 CHECKS += [
     RangeCheck(
@@ -2956,7 +2929,8 @@ CHECKS += [
     )
     for col in vegetation_parameter_columns_singular
 ]
-# TODO: replace with check for cross_section_friction_values and cross_section_vegetation_table
+# TODO: add check for formatting cross_section_vegetation_table
+# TODO: add check for number of rows for cross_section_vegetation_table
 
 CHECKS += [
     CrossSectionVegetationTableNotNegativeCheck(
@@ -2986,7 +2960,6 @@ CHECKS += [
     )
     for col in vegetation_parameter_columns_singular
 ]
-# TODO: fix
 CHECKS += [
     QueryCheck(
         error_code=193,
@@ -3005,11 +2978,10 @@ CHECKS += [
             )
         ),
         message=(
-            "cross_section_locaiton.cross_section_vegetation_table cannot be used with MANNING type friction"
+            "cross_section_location.cross_section_vegetation_table cannot be used with MANNING type friction"
         ),
     )
 ]
-# TODO: fix
 CHECKS += [
     AllPresentFixedVegetationParameters(
         error_code=194, column=models.CrossSectionLocation.vegetation_height
@@ -3048,7 +3020,6 @@ CHECKS += [
         models.Weir,
     ]
 ]
-# TODO: fix
 CHECKS += [
     CrossSectionVariableFrictionRangeCheck(
         min_value=1,

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -484,7 +484,7 @@ CHECKS += [
     ForeignKeyCheck(
         error_code=69,
         column=models.PumpMap.pump_id,
-        reference_column=models.ConnectionNode.id,
+        reference_column=models.Pump.id,
     ),
 ]
 
@@ -588,7 +588,7 @@ for table in cross_section_tables:
         CrossSectionNullCheck(
             error_code=82,
             column=table.cross_section_height,
-            shapes=(constants.CrossSectionShape.CLOSED_RECTANGLE),
+            shapes=(constants.CrossSectionShape.CLOSED_RECTANGLE,),
         ),
         CrossSectionNullCheck(
             error_code=83,
@@ -2995,6 +2995,7 @@ CHECKS += [
     CrossSectionVegetationCorrectLengthCheck(
         column=models.CrossSectionLocation.cross_section_vegetation_table,
         error_code=196,
+        filters=models.CrossSectionLocation.cross_section_vegetation_table.is_not(None),
         shapes=(
             constants.CrossSectionShape.TABULATED_YZ,
             constants.CrossSectionShape.TABULATED_RECTANGLE,
@@ -3171,20 +3172,16 @@ not_null_columns = [
     models.CrossSectionLocation.reference_level,
     models.Culvert.connection_node_id_start,
     models.Culvert.connection_node_id_end,
-    models.Culvert.material_id,
     models.Culvert.friction_type,
     models.Culvert.friction_value,
     models.Culvert.invert_level_start,
     models.Culvert.invert_level_end,
-    models.ConnectionNode.manhole_bottom_level,
     models.Orifice.connection_node_id_start,
     models.Orifice.connection_node_id_end,
-    models.Orifice.material_id,
     models.Orifice.crest_level,
     models.Orifice.crest_type,
     models.Pipe.connection_node_id_start,
     models.Pipe.connection_node_id_end,
-    models.Pipe.material_id,
     models.Pipe.exchange_type,
     models.Pipe.friction_type,
     models.Pipe.friction_value,

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -938,9 +938,21 @@ CHECKS += [
         models.Culvert,
         models.Orifice,
         models.Pipe,
-        # TODO: fix
-        # models.Pumpstation,
         models.Weir,
+    )
+]
+CHECKS += [
+    QueryCheck(
+        error_code=253,
+        column=models.Pump.connection_node_id,
+        invalid=(
+            Query(models.Pump)
+            .join(models.PumpMap, models.PumpMap.id == models.Pump.id)
+            .filter(
+                models.PumpMap.connection_node_id_end == models.Pump.connection_node_id
+            )
+        ),
+        message="a pump cannot be connected to itself (pump.connection_node_id must not equal the corresponding pump_map.connection_node_id_end)",
     )
 ]
 # TODO: add check to ensure models.PumpMap.connection_node_id_end != models.Pump.connection_node_id

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -227,14 +227,16 @@ CHECKS += [
         column=table.friction_value,
         filters=(
             (table.crest_type == constants.CrestType.BROAD_CRESTED.value)
-            & (table.material_id.is_(None))
+            & ((table.material_id.is_(None)) | (table.friction_type.isnot(None)))
         ),
     )
     for table in [models.Orifice, models.Weir]
 ]
 CHECKS += [
     NotNullCheck(
-        error_code=24, column=table.friction_value, filters=table.material_id.is_(None)
+        error_code=24,
+        column=table.friction_value,
+        filters=((table.material_id.is_(None)) | (table.friction_type.isnot(None))),
     )
     for table in [models.Culvert, models.Pipe]
 ]
@@ -244,7 +246,7 @@ CHECKS += [
         column=table.friction_type,
         filters=(
             (table.crest_type == constants.CrestType.BROAD_CRESTED.value)
-            & (table.material_id.is_(None))
+            & ((table.material_id.is_(None)) | (table.friction_value.isnot(None)))
         ),
     )
     for table in [models.Orifice, models.Weir]
@@ -253,7 +255,7 @@ CHECKS += [
     NotNullCheck(
         error_code=25,
         column=table.friction_type,
-        filters=table.material_id.is_(None),
+        filters=((table.material_id.is_(None)) | (table.friction_value.isnot(None))),
     )
     for table in [models.Culvert, models.Pipe]
 ]

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -408,7 +408,7 @@ CHECKS += [
         level=CheckLevel.ERROR,
         column=models.ConnectionNode.id,
         invalid=Query(models.ConnectionNode)
-        .filter(models.ConnectionNode.manhole_bottom_level.is_(None))
+        .filter(models.ConnectionNode.bottom_level.is_(None))
         .filter(
             models.ConnectionNode.id.notin_(
                 Query(models.Pipe.connection_node_id_start).union_all(
@@ -489,7 +489,7 @@ CHECKS += [
                 ]
             )
         )
-        .filter(models.ConnectionNode.manhole_bottom_level.is_(None))
+        .filter(models.ConnectionNode.bottom_level.is_(None))
         .filter(
             models.ConnectionNode.id.notin_(
                 Query(models.Pipe.connection_node_id_start).union_all(
@@ -511,7 +511,7 @@ CHECKS += [
             ),
         ),
         message=(
-            "connection_nodes.manhole_bottom_level for a node that is connected to a weir or an orifice, "
+            "connection_nodes.bottom_level for a node that is connected to a weir or an orifice, "
             "and that has exchange type CONNECTED or ISOLATED should be defined"
         ),
     )
@@ -523,7 +523,7 @@ CHECKS += [
         level=CheckLevel.WARNING,
         column=models.ConnectionNode.id,
         invalid=Query(models.ConnectionNode)
-        .filter(models.ConnectionNode.manhole_bottom_level.is_(None))
+        .filter(models.ConnectionNode.bottom_level.is_(None))
         .filter(
             models.ConnectionNode.id.not_in(
                 Query(models.Channel.connection_node_id_start).union_all(
@@ -541,7 +541,7 @@ CHECKS += [
             ),
         ),
         message=(
-            "connection_nodes.manhole_bottom_level for a node that is connected to a pipe or a culvert, "
+            "connection_nodes.bottom_level for a node that is connected to a pipe or a culvert, "
             "and that is not connected to a channel should be defined. "
             "In the future, this will lead to an error."
         ),
@@ -911,9 +911,9 @@ CHECKS += [
         )
         .filter(models.ConnectionNode.visualisation != None)
         .filter(
-            table.invert_level_start < models.ConnectionNode.manhole_bottom_level,
+            table.invert_level_start < models.ConnectionNode.bottom_level,
         ),
-        message=f"{table.__tablename__}.invert_level_start should be higher than or equal to connection_node.manhole_bottom_level. In the future, this will lead to an error.",
+        message=f"{table.__tablename__}.invert_level_start should be higher than or equal to connection_node.bottom_level. In the future, this will lead to an error.",
     )
     for table in [models.Pipe, models.Culvert]
 ]
@@ -929,7 +929,7 @@ CHECKS += [
         )
         .filter(models.ConnectionNode.visualisation != None)
         .filter(
-            table.invert_level_end < models.ConnectionNode.manhole_bottom_level,
+            table.invert_level_end < models.ConnectionNode.bottom_level,
         ),
         message=f"{table.__tablename__}.invert_level_end should be higher than or equal to connection_node.bottom_level. In the future, this will lead to an error.",
     )
@@ -948,10 +948,10 @@ CHECKS += [
         .filter(models.ConnectionNode.visualisation != None)
         .filter(
             models.Pump.type_ == constants.PumpType.SUCTION_SIDE,
-            models.Pump.lower_stop_level <= models.ConnectionNode.manhole_bottom_level,
+            models.Pump.lower_stop_level <= models.ConnectionNode.bottom_level,
         ),
         message="pump.lower_stop_level should be higher than "
-        "connection_node.manhole_bottom_level. In the future, this will lead to an error.",
+        "connection_node.bottom_level. In the future, this will lead to an error.",
     ),
     QueryCheck(
         level=CheckLevel.WARNING,
@@ -965,15 +965,15 @@ CHECKS += [
         .filter(models.ConnectionNode.visualisation != None)
         .filter(
             models.Pump.type_ == constants.PumpType.DELIVERY_SIDE,
-            models.Pump.lower_stop_level <= models.ConnectionNode.manhole_bottom_level,
+            models.Pump.lower_stop_level <= models.ConnectionNode.bottom_level,
         ),
         message="pump.lower_stop_level should be higher than "
-        "connection_node.manhole_bottom_level. In the future, this will lead to an error.",
+        "connection_node.bottom_level. In the future, this will lead to an error.",
     ),
     QueryCheck(
         level=CheckLevel.WARNING,
         error_code=106,
-        column=models.ConnectionNode.manhole_bottom_level,
+        column=models.ConnectionNode.bottom_level,
         invalid=Query(models.ConnectionNode)
         .filter(models.ConnectionNode.visualisation != None)
         .filter(
@@ -982,10 +982,9 @@ CHECKS += [
             )
         )
         .filter(
-            models.ConnectionNode.exchange_level
-            < models.ConnectionNode.manhole_bottom_level
+            models.ConnectionNode.exchange_level < models.ConnectionNode.bottom_level
         ),
-        message="connection_node.exchange_level >= connection_node.manhole_bottom_level when "
+        message="connection_node.exchange_level >= connection_node.bottom_level when "
         "connection_node.exchange_type is CONNECTED. In the future, this will lead to an error.",
     ),
     QueryCheck(
@@ -1015,9 +1014,9 @@ CHECKS += [
             (table.connection_node_id_start == models.ConnectionNode.id)
             | (table.connection_node_id_end == models.ConnectionNode.id),
         )
-        .filter(models.ConnectionNode.manhole_bottom_level != None)
-        .filter(table.crest_level < models.ConnectionNode.manhole_bottom_level),
-        message=f"{table.__tablename__}.crest_level should be higher than or equal to connection_node.manhole_bottom_level for all the connected manholes.",
+        .filter(models.ConnectionNode.bottom_level != None)
+        .filter(table.crest_level < models.ConnectionNode.bottom_level),
+        message=f"{table.__tablename__}.crest_level should be higher than or equal to connection_node.bottom_level for all the connected manholes.",
     )
     for table in [models.Weir, models.Orifice]
 ]
@@ -1099,7 +1098,7 @@ CHECKS += [
         level=CheckLevel.WARNING,
         column=models.ConnectionNode.id,
         invalid=Query(models.ConnectionNode)
-        .filter(models.ConnectionNode.manhole_bottom_level != None)
+        .filter(models.ConnectionNode.bottom_level != None)
         .filter(
             models.ConnectionNode.exchange_type
             == constants.CalculationTypeNode.ISOLATED,

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -132,6 +132,11 @@ CONDITIONS = {
 
 nr_grid_levels = Query(models.ModelSettings.nr_grid_levels).scalar_subquery()
 
+cross_section_tables = [models.CrossSectionLocation,
+                        models.Culvert,
+                        models.Orifice,
+                        models.Pipe,
+                        models.Weir]
 
 CHECKS: List[BaseCheck] = []
 
@@ -286,6 +291,7 @@ CHECKS += [
     OpenIncreasingCrossSectionConveyanceFrictionCheck(
         error_code=28,
     )
+    for table in cross_section_tables
 ]
 
 ## 003x: CALCULATION TYPE
@@ -395,11 +401,11 @@ CHECKS += [
         message="v2_channel has no cross section locations",
     ),
     # TODO fix
-    CrossSectionSameConfigurationCheck(
-        error_code=56,
-        level=CheckLevel.ERROR,
-        column=models.Channel.id,
-    ),
+    # CrossSectionSameConfigurationCheck(
+    #     error_code=56,
+    #     level=CheckLevel.ERROR,
+    #     column=models.Channel.id,
+    # ),
 ]
 # TODO: fix
 # CHECKS += [
@@ -563,149 +569,117 @@ CHECKS += [
     )
 ]
 
-cross_section_tables = [models.CrossSectionLocation,
-                        models.Culvert,
-                        models.Orifice,
-                        models.Pipe,
-                        models.Weir]
 
-CHECKS += [
-    CrossSectionNullCheck(
-        error_code=81,
-        column=table.cross_section_width,
-        shapes=None,  # all shapes
-    )
-    for table in cross_section_tables
-]
-CHECKS += [
-    CrossSectionNullCheck(
-        error_code=82,
-        column=table.cross_section_height,
-        shapes=(
-            constants.CrossSectionShape.CLOSED_RECTANGLE,
-            constants.CrossSectionShape.TABULATED_RECTANGLE,
-            constants.CrossSectionShape.TABULATED_TRAPEZIUM,
-            constants.CrossSectionShape.TABULATED_YZ,
+for table in cross_section_tables:
+    CHECKS += [
+        CrossSectionNullCheck(
+            error_code=81,
+            column=table.cross_section_width,
+            shapes=None,  # all shapes
         ),
-    )
-    for table in cross_section_tables
-]
-CHECKS += [
-CrossSectionFloatCheck(
-        error_code=83,
-        column=table.cross_section_width,
-        shapes=(
-            constants.CrossSectionShape.RECTANGLE,
-            constants.CrossSectionShape.CIRCLE,
-            constants.CrossSectionShape.CLOSED_RECTANGLE,
-            constants.CrossSectionShape.EGG,
+        CrossSectionNullCheck(
+            error_code=82,
+            column=table.cross_section_height,
+            shapes=(
+                constants.CrossSectionShape.CLOSED_RECTANGLE,
+                constants.CrossSectionShape.TABULATED_RECTANGLE,
+                constants.CrossSectionShape.TABULATED_TRAPEZIUM,
+                constants.CrossSectionShape.TABULATED_YZ,
+            ),
         ),
-    )
-    for table in cross_section_tables
-]
-CHECKS += [
-    CrossSectionFloatCheck(
-        error_code=84,
-        column=table.cross_section_height,
-        shapes=(constants.CrossSectionShape.CLOSED_RECTANGLE,),
-    )
-    for table in cross_section_tables
-]
-CHECKS += [
-    CrossSectionGreaterZeroCheck(
-        error_code=85,
-        column=table.cross_section_width,
-        shapes=(
-            constants.CrossSectionShape.RECTANGLE,
-            constants.CrossSectionShape.CIRCLE,
-            constants.CrossSectionShape.CLOSED_RECTANGLE,
-            constants.CrossSectionShape.EGG,
-            constants.CrossSectionShape.INVERTED_EGG,
+        CrossSectionFloatCheck(
+            error_code=83,
+            column=table.cross_section_width,
+            shapes=(
+                constants.CrossSectionShape.RECTANGLE,
+                constants.CrossSectionShape.CIRCLE,
+                constants.CrossSectionShape.CLOSED_RECTANGLE,
+                constants.CrossSectionShape.EGG,
+            ),
         ),
-    )
-    for table in cross_section_tables
-]
-CHECKS += [
-    CrossSectionGreaterZeroCheck(
-        error_code=86,
-        column=table.cross_section_height,
-        shapes=(constants.CrossSectionShape.CLOSED_RECTANGLE,),
-    )
-    for table in cross_section_tables
-]
-CHECKS += [
-    CrossSectionTableCheck(
-        error_code=87,
-        column=table.cross_section_table,
-        shapes=(
-            constants.CrossSectionShape.TABULATED_RECTANGLE,
-            constants.CrossSectionShape.TABULATED_TRAPEZIUM,
-            constants.CrossSectionShape.TABULATED_YZ,
+        CrossSectionFloatCheck(
+            error_code=84,
+            column=table.cross_section_height,
+            shapes=(constants.CrossSectionShape.CLOSED_RECTANGLE,),
         ),
-    )
-    for table in cross_section_tables
-]
-CHECKS += [
-    CrossSectionIncreasingCheck(
-        error_code=90,
-        column=table.cross_section_height,
-        shapes=(
-            constants.CrossSectionShape.TABULATED_RECTANGLE,
-            constants.CrossSectionShape.TABULATED_TRAPEZIUM,
+        CrossSectionGreaterZeroCheck(
+            error_code=85,
+            column=table.cross_section_width,
+            shapes=(
+                constants.CrossSectionShape.RECTANGLE,
+                constants.CrossSectionShape.CIRCLE,
+                constants.CrossSectionShape.CLOSED_RECTANGLE,
+                constants.CrossSectionShape.EGG,
+                constants.CrossSectionShape.INVERTED_EGG,
+            ),
         ),
-    )
-    for table in cross_section_tables
-]
-CHECKS += [
-    CrossSectionFirstElementNonZeroCheck(
-        error_code=91,
-        column=table.cross_section_table,
-        idx=0,
-        shapes=(constants.CrossSectionShape.TABULATED_RECTANGLE,),
-    )
-    for table in cross_section_tables
-]
-CHECKS += [
-    CrossSectionFirstElementZeroCheck(
-        error_code=92,
-        level=CheckLevel.WARNING,
-        column=table.cross_section_height,
-        idx=1,
-        shapes=(
-            constants.CrossSectionShape.TABULATED_RECTANGLE,
-            constants.CrossSectionShape.TABULATED_TRAPEZIUM,
+        CrossSectionGreaterZeroCheck(
+            error_code=86,
+            column=table.cross_section_height,
+            shapes=(constants.CrossSectionShape.CLOSED_RECTANGLE,),
         ),
-    )
-    for table in cross_section_tables
-]
-#     CrossSectionExpectEmptyCheck(
-#         error_code=94,
-#         level=CheckLevel.WARNING,
-#         column=models.CrossSectionLocation.cross_section_height,
-#         shapes=(
-#             constants.CrossSectionShape.CIRCLE,
-#             constants.CrossSectionShape.EGG,
-#             constants.CrossSectionShape.INVERTED_EGG,
-#         ),
-#     ),
-#     CrossSectionYZHeightCheck(
-#         error_code=95,
-#         column=models.CrossSectionLocation.cross_section_height,
-#         shapes=(constants.CrossSectionShape.TABULATED_YZ,),
-#     ),
-#     CrossSectionYZCoordinateCountCheck(
-#         error_code=96,
-#         shapes=(constants.CrossSectionShape.TABULATED_YZ,),
-#     ),
-#     CrossSectionYZIncreasingWidthIfOpenCheck(
-#         error_code=97,
-#         shapes=(constants.CrossSectionShape.TABULATED_YZ,),
-#     ),
-#     CrossSectionMinimumDiameterCheck(
-#         error_code=98,
-#         level=CheckLevel.WARNING,
-#     ),
-# ]
+        CrossSectionTableCheck(
+            error_code=87,
+            column=table.cross_section_table,
+            shapes=(
+                constants.CrossSectionShape.TABULATED_RECTANGLE,
+                constants.CrossSectionShape.TABULATED_TRAPEZIUM,
+                constants.CrossSectionShape.TABULATED_YZ,
+            ),
+        ),
+        CrossSectionIncreasingCheck(
+            error_code=90,
+            column=table.cross_section_table,
+            shapes=(
+                constants.CrossSectionShape.TABULATED_RECTANGLE,
+                constants.CrossSectionShape.TABULATED_TRAPEZIUM,
+            ),
+        ),
+        CrossSectionFirstElementNonZeroCheck(
+            error_code=91,
+            column=table.cross_section_table,
+            shapes=(constants.CrossSectionShape.TABULATED_RECTANGLE,),
+        ),
+        CrossSectionFirstElementZeroCheck(
+            error_code=92,
+            level=CheckLevel.WARNING,
+            column=table.cross_section_table,
+            shapes=(
+                constants.CrossSectionShape.TABULATED_RECTANGLE,
+                constants.CrossSectionShape.TABULATED_TRAPEZIUM,
+            ),
+        ),
+        CrossSectionExpectEmptyCheck(
+            error_code=94,
+            level=CheckLevel.WARNING,
+            column=models.CrossSectionLocation.cross_section_height,
+            shapes=(
+                constants.CrossSectionShape.CIRCLE,
+                constants.CrossSectionShape.EGG,
+                constants.CrossSectionShape.INVERTED_EGG,
+            ),
+        ),
+        CrossSectionYZHeightCheck(
+            error_code=95,
+            column=models.CrossSectionLocation.cross_section_table,
+            shapes=(constants.CrossSectionShape.TABULATED_YZ,),
+        ),
+        CrossSectionYZCoordinateCountCheck(
+            column=models.CrossSectionLocation.cross_section_table,
+            error_code=96,
+            shapes=(constants.CrossSectionShape.TABULATED_YZ,),
+        ),
+        CrossSectionYZIncreasingWidthIfOpenCheck(
+            column=models.CrossSectionLocation.cross_section_table,
+            error_code=97,
+            shapes=(constants.CrossSectionShape.TABULATED_YZ,),
+        ),
+        CrossSectionMinimumDiameterCheck(
+            column=models.CrossSectionLocation.id,
+            error_code=98,
+            level=CheckLevel.WARNING,
+        ),
+    ]
 CHECKS += [
     CrossSectionTableCheck(
         error_code=87,

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -44,7 +44,7 @@ from .checks.factories import (
     generate_type_checks,
     generate_unique_checks,
 )
-from .checks.other import (  # Use0DFlowCheck,,; ChannelManholeLevelCheck,; ,; FeatureClosedCrossSectionCheck,; OpenChannelsWithNestedNewton,,; CrossSectionSameConfigurationCheck,
+from .checks.other import (  # Use0DFlowCheck,,; ChannelManholeLevelCheck,; ,; ,; OpenChannelsWithNestedNewton,,; CrossSectionSameConfigurationCheck,
     AllPresentFixedVegetationParameters,
     BetaColumnsCheck,
     BetaValuesCheck,
@@ -54,6 +54,7 @@ from .checks.other import (  # Use0DFlowCheck,,; ChannelManholeLevelCheck,; ,; F
     CorrectAggregationSettingsExist,
     CrossSectionLocationCheck,
     DefinedAreaCheck,
+    FeatureClosedCrossSectionCheck,
     InflowNoFeaturesCheck,
     LinestringLocationCheck,
     MaxOneRecordCheck,
@@ -407,12 +408,12 @@ CHECKS += [
     # ),
 ]
 # TODO: fix
-# CHECKS += [
-#     FeatureClosedCrossSectionCheck(
-#         error_code=57, level=CheckLevel.INFO, column=table.id
-#     )
-#     for table in [models.Pipe, models.Culvert]
-# ]
+CHECKS += [
+    FeatureClosedCrossSectionCheck(
+        error_code=57, level=CheckLevel.INFO, column=table.id
+    )
+    for table in [models.Pipe, models.Culvert]
+]
 
 ## 006x: PUMPSTATIONS
 # TODO: fix

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -1188,7 +1188,7 @@ CHECKS += [
             )
             .filter(
                 models.Pipe.exchange_type == constants.PipeCalculationType.ISOLATED,
-                models.ConnectionNode.storage_area,
+                models.ConnectionNode.storage_area.is_(None),
             )
         ),
         message="When connecting two isolated pipes, it is recommended to add storage to the connection node.",

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -2881,12 +2881,12 @@ CHECKS += [
         "are defined for non-conveyance friction. Only cross_section_location.friction_value will be used",
     ),
 ]
-# TODO: add for pipe etc
 CHECKS += [
     OpenIncreasingCrossSectionVariableCheck(
         error_code=186,
-        column=models.CrossSectionLocation.cross_section_friction_values,
+        column=table.id,
     )
+    for table in cross_section_tables
 ]
 ## Friction values range
 # TODO add checks for pipe, etc

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -2704,25 +2704,6 @@ CHECKS += [
 ]
 
 
-# 1230 - 1242
-not_null_cols = [
-    models.ControlMemory.action_type,
-    models.ControlMemory.action_value_1,
-    models.ControlMemory.action_value_2,
-    models.ControlMemory.target_type,
-    models.ControlMemory.target_id,
-    models.ControlTable.action_table,
-    models.ControlTable.action_type,
-    models.ControlTable.target_type,
-    models.ControlMeasureMap.weight,
-    models.ControlMeasureMap.measure_location_id,
-    models.ControlMeasureLocation.connection_node_id,
-    models.ControlMeasureLocation.measure_variable,
-]
-CHECKS += [
-    NotNullCheck(error_code=1230 + i, column=col) for i, col in enumerate(not_null_cols)
-]
-
 # 124x laterals
 CHECKS += [
     QueryCheck(
@@ -3080,6 +3061,62 @@ for pair in BETA_VALUES:
     ]
 
 
+# columns that cannot be NULL in a valid schematisations
+not_null_columns = [
+    models.Channel.exchange_type,
+    models.Channel.connection_node_id_start,
+    models.Channel.connection_node_id_end,
+    models.ControlMeasureMap.weight,
+    models.ControlMeasureMap.measure_location_id,
+    models.ControlMeasureLocation.connection_node_id,
+    models.ControlMeasureLocation.measure_variable,
+    models.ControlMemory.action_type,
+    models.ControlMemory.action_value_1,
+    models.ControlMemory.action_value_2,
+    models.ControlMemory.target_type,
+    models.ControlMemory.target_id,
+    models.ControlTable.action_table,
+    models.ControlTable.action_type,
+    models.ControlTable.target_type,
+    models.CrossSectionLocation.channel_id,
+    models.CrossSectionLocation.friction_type,
+    models.CrossSectionLocation.reference_level,
+    models.Culvert.connection_node_id_start,
+    models.Culvert.connection_node_id_end,
+    models.Culvert.material_id,
+    models.Culvert.friction_type,
+    models.Culvert.friction_value,
+    models.Culvert.invert_level_start,
+    models.Culvert.invert_level_end,
+    models.ConnectionNode.manhole_bottom_level,
+    models.Orifice.connection_node_id_start,
+    models.Orifice.connection_node_id_end,
+    models.Orifice.material_id,
+    models.Orifice.crest_level,
+    models.Orifice.crest_type,
+    models.Pipe.connection_node_id_start,
+    models.Pipe.connection_node_id_end,
+    models.Pipe.material_id,
+    models.Pipe.exchange_type,
+    models.Pipe.friction_type,
+    models.Pipe.friction_value,
+    models.Pipe.invert_level_end,
+    models.Pipe.invert_level_start,
+    models.Pump.connection_node_id,
+    models.Pump.capacity,
+    models.Pump.lower_stop_level,
+    models.Pump.start_level,
+    models.Pump.type_,
+    models.PumpMap.pump_id,
+    models.PumpMap.connection_node_id_end,
+    models.Weir.connection_node_id_start,
+    models.Weir.connection_node_id_end,
+    models.Weir.crest_level,
+    models.Weir.crest_type,
+    models.Windshielding.channel_id,
+]
+
+
 class Config:
     """Collection of checks
 
@@ -3101,7 +3138,9 @@ class Config:
                 error_code=1,
             )
             self.checks += generate_unique_checks(model.__table__, error_code=2)
-            self.checks += generate_not_null_checks(model.__table__, error_code=3)
+            self.checks += generate_not_null_checks(
+                model.__table__, error_code=3, extra_not_null_columns=not_null_columns
+            )
             self.checks += generate_type_checks(model.__table__, error_code=4)
             self.checks += generate_geometry_checks(
                 model.__table__,

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -44,7 +44,7 @@ from .checks.factories import (
     generate_type_checks,
     generate_unique_checks,
 )
-from .checks.other import (  # Use0DFlowCheck,,;,; ,; ,; ,,; CrossSectionSameConfigurationCheck,
+from .checks.other import (  # Use0DFlowCheck,,;,; ,; ,; ,,; ,
     AllPresentFixedVegetationParameters,
     BetaColumnsCheck,
     BetaValuesCheck,
@@ -55,6 +55,7 @@ from .checks.other import (  # Use0DFlowCheck,,;,; ,; ,; ,,; CrossSectionSameCon
     ControlHasSingleMeasureVariable,
     CorrectAggregationSettingsExist,
     CrossSectionLocationCheck,
+    CrossSectionSameConfigurationCheck,
     DefinedAreaCheck,
     FeatureClosedCrossSectionCheck,
     InflowNoFeaturesCheck,
@@ -408,11 +409,11 @@ CHECKS += [
         message="v2_channel has no cross section locations",
     ),
     # TODO fix
-    # CrossSectionSameConfigurationCheck(
-    #     error_code=56,
-    #     level=CheckLevel.ERROR,
-    #     column=models.Channel.id,
-    # ),
+    CrossSectionSameConfigurationCheck(
+        error_code=56,
+        level=CheckLevel.ERROR,
+        column=models.Channel.id,
+    ),
 ]
 # TODO: fix
 CHECKS += [

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -17,7 +17,7 @@ from .checks.base import (
     RangeCheck,
     UniqueCheck,
 )
-from .checks.cross_section_definitions import (  # CrossSectionVariableRangeCheck,
+from .checks.cross_section_definitions import (
     CrossSectionExpectEmptyCheck,
     CrossSectionFirstElementNonZeroCheck,
     CrossSectionFirstElementZeroCheck,
@@ -2957,7 +2957,6 @@ CHECKS += [
     for col in vegetation_parameter_columns_singular
 ]
 # TODO: replace with check for cross_section_friction_values and cross_section_vegetation_table
-# TODO: add CrossSectionVariableRangeCheck for cross_section_vegetation_table
 
 CHECKS += [
     CrossSectionVegetationTableNotNegativeCheck(

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -18,12 +18,11 @@ from .checks.base import (
     UniqueCheck,
 )
 from .checks.cross_section_definitions import (  # CrossSectionVariableRangeCheck,
-    CrossSectionEqualElementsCheck,
     CrossSectionExpectEmptyCheck,
     CrossSectionFirstElementNonZeroCheck,
     CrossSectionFirstElementZeroCheck,
     CrossSectionFloatCheck,
-    CrossSectionFloatListCheck,
+    CrossSectionTableCheck,
     CrossSectionGreaterZeroCheck,
     CrossSectionIncreasingCheck,
     CrossSectionMinimumDiameterCheck,
@@ -563,40 +562,59 @@ CHECKS += [
         f"must be defined for a {constants.CrossSectionShape.TABULATED_YZ} cross section shape",
     )
 ]
+
+cross_section_tables = [models.CrossSectionLocation,
+                        models.Culvert,
+                        models.Orifice,
+                        models.Pipe,
+                        models.Weir]
+
 CHECKS += [
     CrossSectionNullCheck(
         error_code=81,
-        column=models.CrossSectionLocation.cross_section_width,
+        column=table.cross_section_width,
         shapes=None,  # all shapes
-    ),
+    )
+    for table in cross_section_tables
+]
+CHECKS += [
     CrossSectionNullCheck(
         error_code=82,
-        column=models.CrossSectionLocation.cross_section_height,
+        column=table.cross_section_height,
         shapes=(
             constants.CrossSectionShape.CLOSED_RECTANGLE,
             constants.CrossSectionShape.TABULATED_RECTANGLE,
             constants.CrossSectionShape.TABULATED_TRAPEZIUM,
             constants.CrossSectionShape.TABULATED_YZ,
         ),
-    ),
-    CrossSectionFloatCheck(
+    )
+    for table in cross_section_tables
+]
+CHECKS += [
+CrossSectionFloatCheck(
         error_code=83,
-        column=models.CrossSectionLocation.cross_section_width,
+        column=table.cross_section_width,
         shapes=(
             constants.CrossSectionShape.RECTANGLE,
             constants.CrossSectionShape.CIRCLE,
             constants.CrossSectionShape.CLOSED_RECTANGLE,
             constants.CrossSectionShape.EGG,
         ),
-    ),
+    )
+    for table in cross_section_tables
+]
+CHECKS += [
     CrossSectionFloatCheck(
         error_code=84,
-        column=models.CrossSectionLocation.cross_section_height,
+        column=table.cross_section_height,
         shapes=(constants.CrossSectionShape.CLOSED_RECTANGLE,),
-    ),
+    )
+    for table in cross_section_tables
+]
+CHECKS += [
     CrossSectionGreaterZeroCheck(
         error_code=85,
-        column=models.CrossSectionLocation.cross_section_width,
+        column=table.cross_section_width,
         shapes=(
             constants.CrossSectionShape.RECTANGLE,
             constants.CrossSectionShape.CIRCLE,
@@ -604,90 +622,92 @@ CHECKS += [
             constants.CrossSectionShape.EGG,
             constants.CrossSectionShape.INVERTED_EGG,
         ),
-    ),
+    )
+    for table in cross_section_tables
+]
+CHECKS += [
     CrossSectionGreaterZeroCheck(
         error_code=86,
-        column=models.CrossSectionLocation.cross_section_height,
+        column=table.cross_section_height,
         shapes=(constants.CrossSectionShape.CLOSED_RECTANGLE,),
-    ),
-    CrossSectionFloatListCheck(
+    )
+    for table in cross_section_tables
+]
+CHECKS += [
+    CrossSectionTableCheck(
         error_code=87,
-        column=models.CrossSectionLocation.cross_section_width,
+        column=table.cross_section_table,
         shapes=(
             constants.CrossSectionShape.TABULATED_RECTANGLE,
             constants.CrossSectionShape.TABULATED_TRAPEZIUM,
             constants.CrossSectionShape.TABULATED_YZ,
         ),
-    ),
-    CrossSectionFloatListCheck(
-        error_code=88,
-        column=models.CrossSectionLocation.cross_section_height,
-        shapes=(
-            constants.CrossSectionShape.TABULATED_RECTANGLE,
-            constants.CrossSectionShape.TABULATED_TRAPEZIUM,
-            constants.CrossSectionShape.TABULATED_YZ,
-        ),
-    ),
-    CrossSectionEqualElementsCheck(
-        error_code=89,
-        shapes=(
-            constants.CrossSectionShape.TABULATED_RECTANGLE,
-            constants.CrossSectionShape.TABULATED_TRAPEZIUM,
-            constants.CrossSectionShape.TABULATED_YZ,
-        ),
-    ),
+    )
+    for table in cross_section_tables
+]
+CHECKS += [
     CrossSectionIncreasingCheck(
         error_code=90,
-        column=models.CrossSectionLocation.cross_section_height,
+        column=table.cross_section_height,
         shapes=(
             constants.CrossSectionShape.TABULATED_RECTANGLE,
             constants.CrossSectionShape.TABULATED_TRAPEZIUM,
         ),
-    ),
+    )
+    for table in cross_section_tables
+]
+CHECKS += [
     CrossSectionFirstElementNonZeroCheck(
         error_code=91,
-        column=models.CrossSectionLocation.cross_section_width,
+        column=table.cross_section_table,
+        idx=0,
         shapes=(constants.CrossSectionShape.TABULATED_RECTANGLE,),
-    ),
+    )
+    for table in cross_section_tables
+]
+CHECKS += [
     CrossSectionFirstElementZeroCheck(
         error_code=92,
         level=CheckLevel.WARNING,
-        column=models.CrossSectionLocation.cross_section_height,
+        column=table.cross_section_height,
+        idx=1,
         shapes=(
             constants.CrossSectionShape.TABULATED_RECTANGLE,
             constants.CrossSectionShape.TABULATED_TRAPEZIUM,
         ),
-    ),
-    CrossSectionExpectEmptyCheck(
-        error_code=94,
-        level=CheckLevel.WARNING,
-        column=models.CrossSectionLocation.cross_section_height,
-        shapes=(
-            constants.CrossSectionShape.CIRCLE,
-            constants.CrossSectionShape.EGG,
-            constants.CrossSectionShape.INVERTED_EGG,
-        ),
-    ),
-    CrossSectionYZHeightCheck(
-        error_code=95,
-        column=models.CrossSectionLocation.cross_section_height,
-        shapes=(constants.CrossSectionShape.TABULATED_YZ,),
-    ),
-    CrossSectionYZCoordinateCountCheck(
-        error_code=96,
-        shapes=(constants.CrossSectionShape.TABULATED_YZ,),
-    ),
-    CrossSectionYZIncreasingWidthIfOpenCheck(
-        error_code=97,
-        shapes=(constants.CrossSectionShape.TABULATED_YZ,),
-    ),
-    CrossSectionMinimumDiameterCheck(
-        error_code=98,
-        level=CheckLevel.WARNING,
-    ),
+    )
+    for table in cross_section_tables
 ]
+#     CrossSectionExpectEmptyCheck(
+#         error_code=94,
+#         level=CheckLevel.WARNING,
+#         column=models.CrossSectionLocation.cross_section_height,
+#         shapes=(
+#             constants.CrossSectionShape.CIRCLE,
+#             constants.CrossSectionShape.EGG,
+#             constants.CrossSectionShape.INVERTED_EGG,
+#         ),
+#     ),
+#     CrossSectionYZHeightCheck(
+#         error_code=95,
+#         column=models.CrossSectionLocation.cross_section_height,
+#         shapes=(constants.CrossSectionShape.TABULATED_YZ,),
+#     ),
+#     CrossSectionYZCoordinateCountCheck(
+#         error_code=96,
+#         shapes=(constants.CrossSectionShape.TABULATED_YZ,),
+#     ),
+#     CrossSectionYZIncreasingWidthIfOpenCheck(
+#         error_code=97,
+#         shapes=(constants.CrossSectionShape.TABULATED_YZ,),
+#     ),
+#     CrossSectionMinimumDiameterCheck(
+#         error_code=98,
+#         level=CheckLevel.WARNING,
+#     ),
+# ]
 CHECKS += [
-    CrossSectionFloatListCheck(
+    CrossSectionTableCheck(
         error_code=87,
         column=models.CrossSectionLocation.cross_section_friction_values,
         shapes=(constants.CrossSectionShape.TABULATED_YZ,),

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -404,7 +404,7 @@ CHECKS += [
             models.ConnectionNode.visualisation != None,
             models.ConnectionNode.storage_area < 0,
         ),
-        message="connection_nodes.storage_area for manhole connection node should greater than or equal to 0",
+        message="connection_node.storage_area for manhole connection node should greater than or equal to 0",
     ),
 ]
 CHECKS += [
@@ -445,7 +445,8 @@ CHECKS += [
                 )
             ),
         ),
-        message="connection_nodes.storage_area for an isolated node should be defined and greater than 0",
+        message="connection_node.storage_area should be defined and greater than 0 if the connection nodes "
+        "has no connections to channels, culverts, pipes, weirs, or orifices0",
     )
 ]
 
@@ -516,7 +517,7 @@ CHECKS += [
             ),
         ),
         message=(
-            "connection_nodes.storage_area for a node that is connected to a weir or an orifice, "
+            "connection_node.storage_area for a node that is connected to a weir or an orifice, "
             "and that has exchange type CONNECTED or ISOLATED should be defined and greater than 0"
         ),
     )
@@ -558,7 +559,7 @@ CHECKS += [
             ),
         ),
         message=(
-            "connection_nodes.bottom_level for a node that is connected to a weir or an orifice, "
+            "connection_node.bottom_level for a node that is connected to a weir or an orifice, "
             "and that has exchange type CONNECTED or ISOLATED should be defined"
         ),
     )
@@ -588,7 +589,7 @@ CHECKS += [
             ),
         ),
         message=(
-            "connection_nodes.bottom_level for a node that is connected to a pipe or a culvert, "
+            "connection_node.bottom_level for a node that is connected to a pipe or a culvert, "
             "and that is not connected to a channel should be defined. "
             "In the future, this will lead to an error."
         ),
@@ -624,7 +625,7 @@ CHECKS += [
             ),
         ),
         message=(
-            "connection_nodes.storage_area for a node that is connected to a pipe or a culvert, "
+            "connection_node.storage_area for a node that is connected to a pipe or a culvert, "
             "and that is not connected to a channel should be defined and greater than 0"
             "In the future, this will lead to an error."
         ),
@@ -1166,8 +1167,7 @@ CHECKS += [
                 )
             ),
         ),
-        message="This is an isolated connection node without connections. Connect it to either a pipe, "
-        "channel, culvert, weir, orifice or pumpstation.",
+        message="This connection node is not connected to a pipe, channel, culvert, weir, orifice or pumpstation.",
     ),
     QueryCheck(
         level=CheckLevel.WARNING,

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -253,7 +253,7 @@ CHECKS += [
         ),
         message=(
             "Friction with conveyance, such as chezy_conveyance and "
-            "manning_conveyance, may only be used with v2_cross_section_location"
+            "manning_conveyance, may only be used with cross_section_location"
         ),
     )
     for table in [models.Pipe, models.Culvert, models.Weir, models.Orifice]
@@ -284,7 +284,7 @@ CHECKS += [
             )
         ),
         message=(
-            "in v2_cross_section_location, friction with "
+            "in cross_section_location, friction with "
             "conveyance, such as chezy_conveyance and "
             "manning_conveyance, may only be used with "
             "tabulated rectangle (5), tabulated trapezium (6), "
@@ -313,7 +313,7 @@ CHECKS += [
                 ]
             ),
         ),
-        message=f"v2_channel.exchange_type cannot be "
+        message=f"channel.exchange_type cannot be "
         f"{constants.CalculationType.EMBEDDED}, "
         f"{constants.CalculationType.CONNECTED} or "
         f"{constants.CalculationType.DOUBLE_CONNECTED} when "
@@ -392,7 +392,7 @@ CHECKS += [
             models.CrossSectionLocation.reference_level
             > models.CrossSectionLocation.bank_level,
         ),
-        message="v2_cross_section_location.bank_level will be ignored if it is below the reference_level",
+        message="cross_section_location.bank_level will be ignored if it is below the reference_level",
     ),
     QueryCheck(
         error_code=55,
@@ -403,7 +403,7 @@ CHECKS += [
             models.Channel.id == models.CrossSectionLocation.channel_id,
         )
         .filter(models.CrossSectionLocation.channel_id == None),
-        message="v2_channel has no cross section locations",
+        message="channel has no cross section locations",
     ),
     CrossSectionSameConfigurationCheck(
         error_code=56,
@@ -1040,7 +1040,7 @@ CHECKS += [
                 }
             )
         ),
-        message="v2_channel can only have an exchange_line if it has "
+        message="channel can only have an exchange_line if it has "
         "a (double) connected (102 or 105) calculation type",
     ),
     QueryCheck(
@@ -1054,7 +1054,7 @@ CHECKS += [
         )
         .group_by(models.ExchangeLine.channel_id)
         .having(func.count(models.ExchangeLine.id) > 1),
-        message="v2_channel can have max 1 exchange_line if it has "
+        message="channel can have max 1 exchange_line if it has "
         "connected (102) calculation type",
     ),
     QueryCheck(
@@ -1068,7 +1068,7 @@ CHECKS += [
         )
         .group_by(models.ExchangeLine.channel_id)
         .having(func.count(models.ExchangeLine.id) > 2),
-        message="v2_channel can have max 2 exchange_line if it has "
+        message="channel can have max 2 exchange_line if it has "
         "double connected (105) calculation type",
     ),
     QueryCheck(
@@ -1145,7 +1145,7 @@ CHECKS += [
             func.PointN(models.PotentialBreach.geom, 1),
         )
         .having(func.count(models.PotentialBreach.id) > 1),
-        message="v2_channel can have max 1 potential_breach at the same position "
+        message="channel can have max 1 potential_breach at the same position "
         "on a channel of connected (102) calculation type",
     ),
     QueryCheck(
@@ -1162,7 +1162,7 @@ CHECKS += [
             func.PointN(models.PotentialBreach.geom, 1),
         )
         .having(func.count(models.PotentialBreach.id) > 2),
-        message="v2_channel can have max 2 potential_breach at the same position "
+        message="channel can have max 2 potential_breach at the same position "
         "on a channel of double connected (105) calculation type",
     ),
     QueryCheck(
@@ -2525,7 +2525,7 @@ CHECKS += [
             models.AggregationSettings.interval
             < models.TimeStepSettings.output_time_step
         ),
-        message="v2_aggregation_settings.timestep is smaller than v2_global_settings.output_time_step",
+        message="aggregation_settings.timestep is smaller than time_step_settings.output_time_step",
     ),
 ]
 CHECKS += [
@@ -3122,9 +3122,8 @@ class Config:
                 model.__table__,
                 error_code=7,
                 custom_level_map={
-                    "*.zoom_category": "INFO",
-                    "v2_pipe.sewerage_type": "INFO",
-                    "v2_pipe.material": "INFO",
+                    "pipe.sewerage_type": "INFO",
+                    "pipe.material": "INFO",
                 },
             )
             self.checks += [

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -22,11 +22,11 @@ from .checks.cross_section_definitions import (  # CrossSectionVariableRangeChec
     CrossSectionFirstElementNonZeroCheck,
     CrossSectionFirstElementZeroCheck,
     CrossSectionFloatCheck,
-    CrossSectionTableCheck,
     CrossSectionGreaterZeroCheck,
     CrossSectionIncreasingCheck,
     CrossSectionMinimumDiameterCheck,
     CrossSectionNullCheck,
+    CrossSectionTableCheck,
     CrossSectionVariableCorrectLengthCheck,
     CrossSectionVariableFrictionRangeCheck,
     CrossSectionYZCoordinateCountCheck,
@@ -132,11 +132,13 @@ CONDITIONS = {
 
 nr_grid_levels = Query(models.ModelSettings.nr_grid_levels).scalar_subquery()
 
-cross_section_tables = [models.CrossSectionLocation,
-                        models.Culvert,
-                        models.Orifice,
-                        models.Pipe,
-                        models.Weir]
+cross_section_tables = [
+    models.CrossSectionLocation,
+    models.Culvert,
+    models.Orifice,
+    models.Pipe,
+    models.Weir,
+]
 
 CHECKS: List[BaseCheck] = []
 
@@ -290,6 +292,7 @@ CHECKS += [
 CHECKS += [
     OpenIncreasingCrossSectionConveyanceFrictionCheck(
         error_code=28,
+        column=table.id
     )
     for table in cross_section_tables
 ]

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -882,7 +882,7 @@ for table in cross_section_tables:
         CrossSectionExpectEmptyCheck(
             error_code=94,
             level=CheckLevel.WARNING,
-            column=models.CrossSectionLocation.cross_section_height,
+            column=table.cross_section_height,
             shapes=(
                 constants.CrossSectionShape.CIRCLE,
                 constants.CrossSectionShape.EGG,
@@ -891,23 +891,24 @@ for table in cross_section_tables:
         ),
         CrossSectionYZHeightCheck(
             error_code=95,
-            column=models.CrossSectionLocation.cross_section_table,
+            column=table.cross_section_table,
             shapes=(constants.CrossSectionShape.TABULATED_YZ,),
         ),
         CrossSectionYZCoordinateCountCheck(
-            column=models.CrossSectionLocation.cross_section_table,
+            column=table.cross_section_table,
             error_code=96,
             shapes=(constants.CrossSectionShape.TABULATED_YZ,),
         ),
         CrossSectionYZIncreasingWidthIfOpenCheck(
-            column=models.CrossSectionLocation.cross_section_table,
+            column=table.cross_section_table,
             error_code=97,
             shapes=(constants.CrossSectionShape.TABULATED_YZ,),
         ),
         CrossSectionMinimumDiameterCheck(
-            column=models.CrossSectionLocation.id,
+            column=table.id,
             error_code=98,
             level=CheckLevel.WARNING,
+            filters=table.cross_section_shape.isnot(None),
         ),
     ]
 
@@ -3065,6 +3066,7 @@ CHECKS += [
     OpenIncreasingCrossSectionVariableCheck(
         error_code=186,
         column=table.id,
+        filters=table.cross_section_shape.isnot(None),
     )
     for table in cross_section_tables
 ]

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -2771,7 +2771,7 @@ CHECKS += [
         error_code=181,
         column=models.CrossSectionLocation.cross_section_friction_values,
         shapes=(constants.CrossSectionShape.TABULATED_YZ,),
-        filters=models.CrossSectionLocation.cross_section_height.is_not(None)
+        filters=models.CrossSectionLocation.cross_section_table.is_not(None)
         & models.CrossSectionLocation.cross_section_friction_values.is_not(None),
     )
 ]

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -44,7 +44,7 @@ from .checks.factories import (
     generate_type_checks,
     generate_unique_checks,
 )
-from .checks.other import (  # Use0DFlowCheck,,;,; ,; ,; OpenChannelsWithNestedNewton,,; CrossSectionSameConfigurationCheck,
+from .checks.other import (  # Use0DFlowCheck,,;,; ,; ,; ,,; CrossSectionSameConfigurationCheck,
     AllPresentFixedVegetationParameters,
     BetaColumnsCheck,
     BetaValuesCheck,
@@ -60,6 +60,7 @@ from .checks.other import (  # Use0DFlowCheck,,;,; ,; ,; OpenChannelsWithNestedN
     LinestringLocationCheck,
     MaxOneRecordCheck,
     NodeSurfaceConnectionsCheck,
+    OpenChannelsWithNestedNewton,
     PotentialBreachInterdistanceCheck,
     PotentialBreachStartEndCheck,
     PumpStorageTimestepCheck,
@@ -374,11 +375,14 @@ CHECKS += [
 ## 005x: CROSS SECTIONS
 
 CHECKS += [
+    OpenChannelsWithNestedNewton(error_code=53, column=table.id)
+    for table in cross_section_tables
+]
+
+CHECKS += [
     CrossSectionLocationCheck(
         level=CheckLevel.WARNING, max_distance=TOLERANCE_M, error_code=52
     ),
-    # TODO: fix
-    # OpenChannelsWithNestedNewton(error_code=53),
     QueryCheck(
         error_code=54,
         level=CheckLevel.WARNING,

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -44,7 +44,7 @@ from .checks.factories import (
     generate_type_checks,
     generate_unique_checks,
 )
-from .checks.other import (  # Use0DFlowCheck,,; ChannelManholeLevelCheck,; ,; FeatureClosedCrossSectionCheck,; OpenChannelsWithNestedNewton,,
+from .checks.other import (  # Use0DFlowCheck,,; ChannelManholeLevelCheck,; ,; FeatureClosedCrossSectionCheck,; OpenChannelsWithNestedNewton,,; CrossSectionSameConfigurationCheck,
     AllPresentFixedVegetationParameters,
     BetaColumnsCheck,
     BetaValuesCheck,
@@ -53,7 +53,6 @@ from .checks.other import (  # Use0DFlowCheck,,; ChannelManholeLevelCheck,; ,; F
     ConnectionNodesLength,
     CorrectAggregationSettingsExist,
     CrossSectionLocationCheck,
-    CrossSectionSameConfigurationCheck,
     DefinedAreaCheck,
     InflowNoFeaturesCheck,
     LinestringLocationCheck,
@@ -290,10 +289,7 @@ CHECKS += [
 ]
 # TODO: fix
 CHECKS += [
-    OpenIncreasingCrossSectionConveyanceFrictionCheck(
-        error_code=28,
-        column=table.id
-    )
+    OpenIncreasingCrossSectionConveyanceFrictionCheck(error_code=28, column=table.id)
     for table in cross_section_tables
 ]
 

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -3366,6 +3366,7 @@ not_null_columns = [
     models.Weir.crest_level,
     models.Weir.crest_type,
     models.Windshielding.channel_id,
+    models.ModelSettings.node_open_water_detection,
 ]
 
 

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -984,6 +984,18 @@ CHECKS += [
     ),
 ]
 
+for i, table in enumerate(
+    [models.Channel, models.Culvert, models.Orifice, models.Pipe, models.Weir]
+):
+    CHECKS += [
+        ForeignKeyCheck(
+            error_code=255 + i,
+            column=col,
+            reference_column=models.ConnectionNode.id,
+        )
+        for col in [table.connection_node_id_start, table.connection_node_id_end]
+    ]
+
 
 ## 026x: Exchange lines
 CHECKS += [

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -360,6 +360,37 @@ CHECKS += [
         message="connection_nodes.storage_area for manhole connection node should greater than or equal to 0",
     ),
 ]
+
+CHECKS += [
+    QueryCheck(
+        error_code=44,
+        level=CheckLevel.ERROR,
+        column=models.ConnectionNode.id,
+        invalid=Query(models.ConnectionNode)
+        .filter(
+            or_(
+                models.ConnectionNode.storage_area.is_(None),
+                models.ConnectionNode.storage_area < 0,
+            )
+        )
+        .filter(
+            models.ConnectionNode.id.notin_(
+                Query(models.Pipe.connection_node_id_start).union_all(
+                    Query(models.Pipe.connection_node_id_end),
+                    Query(models.Channel.connection_node_id_start),
+                    Query(models.Channel.connection_node_id_end),
+                    Query(models.Culvert.connection_node_id_start),
+                    Query(models.Culvert.connection_node_id_end),
+                    Query(models.Weir.connection_node_id_start),
+                    Query(models.Weir.connection_node_id_end),
+                    Query(models.Orifice.connection_node_id_start),
+                    Query(models.Orifice.connection_node_id_end),
+                )
+            ),
+        ),
+        message="connection_nodes.storage_area for an isolated node should be defined and greater than 0",
+    )
+]
 CHECKS += [
     RangeCheck(
         error_code=45,
@@ -987,7 +1018,7 @@ CHECKS += [
         level=CheckLevel.ERROR,
         column=models.ConnectionNode.id,
         invalid=Query(models.ConnectionNode)
-        .filter(models.ConnectionNode.manhole_bottom_level != None)
+        .filter(models.ConnectionNode.manhole_bottom_level.is_(None))
         .filter(
             models.ConnectionNode.id.notin_(
                 Query(models.Pipe.connection_node_id_start).union_all(
@@ -1004,7 +1035,7 @@ CHECKS += [
             ),
         ),
         message="A connection node that is not connected to a pipe, "
-        "channel, culvert, weir, or orifice must have a manhole with a bottom_level.",
+        "channel, culvert, weir, or orifice must have a defined bottom_level.",
     ),
 ]
 

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from sqlalchemy import and_, func, or_, select, true
+from sqlalchemy import and_, func, or_, true
 from sqlalchemy.orm import Query
 from threedi_schema import constants, models
 from threedi_schema.beta_features import BETA_COLUMNS, BETA_VALUES
@@ -3253,7 +3253,12 @@ CHECKS += [
 ]
 
 conditions = [
-    models.Material.id.in_(select(table.material_id)) for table in material_ref_tables
+    and_(
+        table.material_id == models.Material.id,
+        table.friction_value.is_(None),
+        table.friction_type.is_(None),
+    )
+    for table in material_ref_tables
 ]
 CHECKS += [
     NotNullCheck(

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -463,6 +463,21 @@ CHECKS += [
         level=CheckLevel.WARNING,
         column=models.Pump.capacity,
     ),
+    ForeignKeyCheck(
+        error_code=67,
+        column=models.Pump.connection_node_id,
+        reference_column=models.ConnectionNode.id,
+    ),
+    ForeignKeyCheck(
+        error_code=68,
+        column=models.PumpMap.connection_node_id_end,
+        reference_column=models.ConnectionNode.id,
+    ),
+    ForeignKeyCheck(
+        error_code=69,
+        column=models.PumpMap.pump_id,
+        reference_column=models.ConnectionNode.id,
+    ),
 ]
 
 ## 007x: BOUNDARY CONDITIONS
@@ -811,6 +826,14 @@ CHECKS += [
 #         level=CheckLevel.INFO, nodes_to_check="end", error_code=110
 #     ),
 # ]
+
+## Linked channels
+CHECKS += [
+    ForeignKeyCheck(
+        error_code=110 + i, column=table.channel_id, reference_column=models.Channel.id
+    )
+    for i, table in enumerate([models.CrossSectionLocation, models.Windshielding])
+]
 
 ## 020x: Spatial checks
 

--- a/threedi_modelchecker/tests/factories.py
+++ b/threedi_modelchecker/tests/factories.py
@@ -56,7 +56,7 @@ class ChannelFactory(factory.alchemy.SQLAlchemyModelFactory):
         sqlalchemy_session = None
 
     display_name = Faker("name")
-    code = "code"
+    code = Faker("name")
     exchange_type = constants.CalculationType.CONNECTED
     geom = "SRID=4326;LINESTRING(-71.064544 42.28787, -71.0645 42.287)"
 

--- a/threedi_modelchecker/tests/factories.py
+++ b/threedi_modelchecker/tests/factories.py
@@ -61,17 +61,6 @@ class ChannelFactory(factory.alchemy.SQLAlchemyModelFactory):
     geom = "SRID=4326;LINESTRING(-71.064544 42.28787, -71.0645 42.287)"
 
 
-# class ManholeFactory(factory.alchemy.SQLAlchemyModelFactory):
-#     class Meta:
-#         model = models.Manhole
-#         sqlalchemy_session = None
-#
-#     code = Faker("name")
-#     display_name = Faker("name")
-#     bottom_level = 0.0
-#     connection_node = factory.SubFactory(ConnectionNodeFactory)
-
-
 class WeirFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         model = models.Weir

--- a/threedi_modelchecker/tests/factories.py
+++ b/threedi_modelchecker/tests/factories.py
@@ -272,7 +272,6 @@ class CulvertFactory(factory.alchemy.SQLAlchemyModelFactory):
     friction_type = 2
     invert_level_start = 0.1
     invert_level_end = 1.1
-    # cross_section_definition = factory.SubFactory(CrossSectionDefinitionFactory)
     discharge_coefficient_negative = 1.0
     discharge_coefficient_positive = 1.0
 

--- a/threedi_modelchecker/tests/test_checks_base.py
+++ b/threedi_modelchecker/tests/test_checks_base.py
@@ -45,7 +45,6 @@ def test_base_extra_filters_err(session):
     assert len(invalid_rows) == 1
 
 
-@pytest.mark.skip(reason="Needs fixing for schema 227")
 def test_fk_check(session):
     factories.ConnectionNodeFactory(id=1)
     factories.PumpFactory(connection_node_id=1)
@@ -54,22 +53,18 @@ def test_fk_check(session):
     assert len(invalid_rows) == 0
 
 
-@pytest.mark.skip(reason="Needs fixing for schema 227")
 def test_fk_check_no_entries(session):
-    fk_check = ForeignKeyCheck(
-        models.ConnectionNode.id, models.Manhole.connection_node_id
-    )
+    fk_check = ForeignKeyCheck(models.ConnectionNode.id, models.Pump.connection_node_id)
     invalid_rows = fk_check.get_invalid(session)
     assert len(invalid_rows) == 0
 
 
-@pytest.mark.skip(reason="Needs fixing for schema 227")
 def test_fk_check_null_fk(session):
-    conn_node = factories.ConnectionNodeFactory()
-    factories.ManholeFactory.create_batch(5, visualisation=conn_node.id)
-    factories.ManholeFactory(visualisation=None)
+    conn_node = factories.ConnectionNodeFactory(id=1)
+    factories.PumpFactory.create_batch(5, connection_node_id=conn_node.id)
+    factories.PumpFactory(connection_node_id=None)
 
-    fk_check = ForeignKeyCheck(models.ConnectionNode.id, models.Manhole.visualisation)
+    fk_check = ForeignKeyCheck(models.ConnectionNode.id, models.Pump.connection_node_id)
     invalid_rows = fk_check.get_invalid(session)
     assert len(invalid_rows) == 0
 

--- a/threedi_modelchecker/tests/test_checks_base.py
+++ b/threedi_modelchecker/tests/test_checks_base.py
@@ -449,45 +449,6 @@ def test_query_check_with_joins(session):
 
 
 @pytest.mark.skip(reason="Needs fixing for schema 227")
-def test_query_check_on_pumpstation(session):
-    connection_node1 = factories.ConnectionNodeFactory()
-    connection_node2 = factories.ConnectionNodeFactory()
-    factories.ManholeFactory(connection_node=connection_node1, bottom_level=1.0)
-    factories.ManholeFactory(connection_node=connection_node2, bottom_level=-1.0)
-    pumpstation_wrong = factories.PumpstationFactory(
-        connection_node_start=connection_node1, lower_stop_level=0.0
-    )
-    factories.PumpstationFactory(
-        connection_node_start=connection_node2, lower_stop_level=2.0
-    )
-
-    query = (
-        Query(models.Pumpstation)
-        .join(
-            models.ConnectionNode,
-            models.Pumpstation.connection_node_id_start
-            == models.ConnectionNode.id,  # noqa: E501
-        )
-        .join(
-            models.Manhole,
-            models.Manhole.connection_node_id == models.ConnectionNode.id,
-        )
-        .filter(
-            models.Pumpstation.lower_stop_level <= models.Manhole.bottom_level,
-        )
-    )
-    check = QueryCheck(
-        column=models.Pumpstation.lower_stop_level,
-        invalid=query,
-        message="Pumpstation lower_stop_level should be higher than Manhole "
-        "bottom_level",
-    )
-    invalids = check.get_invalid(session)
-    assert len(invalids) == 1
-    assert invalids[0].id == pumpstation_wrong.id
-
-
-@pytest.mark.skip(reason="Needs fixing for schema 227")
 def test_query_check_manhole_drain_level_calc_type_2(session):
     # manhole.drain_level can be null, but if manhole.exchange_type == 2 (Connected)
     # then manhole.drain_level >= manhole.bottom_level

--- a/threedi_modelchecker/tests/test_checks_base.py
+++ b/threedi_modelchecker/tests/test_checks_base.py
@@ -254,16 +254,15 @@ def test_type_check(session):
     assert len(invalid_rows) == 0
 
 
-@pytest.mark.skip(reason="Needs fixing for schema 227")
 def test_type_check_integer(session):
     if session.bind.name == "postgresql":
         pytest.skip("type checks not working on postgres")
-    factories.ManholeFactory(zoom_category=123)
-    factories.ManholeFactory(zoom_category=None)
-    m1 = factories.ManholeFactory(zoom_category="abc")
-    m2 = factories.ManholeFactory(zoom_category=1.23)
+    factories.ChannelFactory(exchange_type=123)
+    factories.ChannelFactory(exchange_type=None)
+    m1 = factories.ChannelFactory(exchange_type="abc")
+    m2 = factories.ChannelFactory(exchange_type=1.23)
 
-    type_check = TypeCheck(models.Manhole.zoom_category)
+    type_check = TypeCheck(models.Channel.exchange_type)
     invalid_rows = type_check.get_invalid(session)
 
     assert len(invalid_rows) == 2

--- a/threedi_modelchecker/tests/test_checks_base.py
+++ b/threedi_modelchecker/tests/test_checks_base.py
@@ -225,12 +225,11 @@ def test_null_check_with_null_value(session):
     assert invalid_rows[0].id == null_node.id
 
 
-@pytest.mark.skip(reason="Needs fixing for schema 227")
 def test_threedi_db_and_factories(session):
     """Test to ensure that the threedi_db and factories use the same
     session object."""
-    factories.ManholeFactory()
-    q = session.query(models.Manhole)
+    factories.ChannelFactory()
+    q = session.query(models.Channel)
     assert q.count() == 1
 
 

--- a/threedi_modelchecker/tests/test_checks_base.py
+++ b/threedi_modelchecker/tests/test_checks_base.py
@@ -552,7 +552,7 @@ def test_length_geom_linestring_in_4326(session):
     check_length_linestring = QueryCheck(
         column=models.Channel.geom,
         invalid=q,
-        message="Length of the v2_channel is too short, should be at least 0.05m",
+        message="Length of the channel is too short, should be at least 0.05m",
     )
 
     errors = check_length_linestring.get_invalid(session)
@@ -578,7 +578,7 @@ def test_length_geom_linestring_missing_epsg_from_global_settings(session):
     check_length_linestring = QueryCheck(
         column=models.Channel.geom,
         invalid=q,
-        message="Length of the v2_channel is too short, should be at least 0.05m",
+        message="Length of the channel is too short, should be at least 0.05m",
     )
 
     errors = check_length_linestring.get_invalid(session)

--- a/threedi_modelchecker/tests/test_checks_base.py
+++ b/threedi_modelchecker/tests/test_checks_base.py
@@ -75,13 +75,13 @@ def test_fk_check_null_fk(session):
     assert len(invalid_rows) == 0
 
 
-@pytest.mark.skip(reason="Needs fixing for schema 227")
 def test_fk_check_missing_fk(session):
     conn_node = factories.ConnectionNodeFactory()
-    factories.ManholeFactory.create_batch(5, visualisation=conn_node.id)
-    missing_fk = factories.ManholeFactory(visualisation=-1)
-
-    fk_check = ForeignKeyCheck(models.ConnectionNode.id, models.Manhole.visualisation)
+    factories.ChannelFactory(connection_node_id_start=conn_node.id)
+    missing_fk = factories.ChannelFactory(connection_node_id_start=-1)
+    fk_check = ForeignKeyCheck(
+        models.ConnectionNode.id, models.Channel.connection_node_id_start
+    )
     invalid_rows = fk_check.get_invalid(session)
     assert len(invalid_rows) == 1
     assert invalid_rows[0].id == missing_fk.id

--- a/threedi_modelchecker/tests/test_checks_base.py
+++ b/threedi_modelchecker/tests/test_checks_base.py
@@ -414,8 +414,8 @@ def test_conditional_check_storage_area(session):
 
 
 def test_query_check_with_joins(session):
-    connection_node1 = factories.ConnectionNodeFactory(id=1, manhole_bottom_level=1.0)
-    connection_node2 = factories.ConnectionNodeFactory(id=2, manhole_bottom_level=-1.0)
+    connection_node1 = factories.ConnectionNodeFactory(id=1, bottom_level=1.0)
+    connection_node2 = factories.ConnectionNodeFactory(id=2, bottom_level=-1.0)
     pump1 = factories.PumpFactory(
         connection_node_id=connection_node1.id, lower_stop_level=0.0
     )
@@ -428,14 +428,14 @@ def test_query_check_with_joins(session):
             models.Pump.connection_node_id == models.ConnectionNode.id,
         )
         .filter(
-            models.Pump.lower_stop_level <= models.ConnectionNode.manhole_bottom_level,
+            models.Pump.lower_stop_level <= models.ConnectionNode.bottom_level,
         )
     )
     check = QueryCheck(
         column=models.Pump.lower_stop_level,
         invalid=query,
         message="Pump.lower_stop_level should be higher than "
-        "ConnectionNode.manhole_bottom_level",
+        "ConnectionNode.bottom_level",
     )
     invalids = check.get_invalid(session)
     assert len(invalids) == 1
@@ -452,23 +452,22 @@ def test_query_check_manhole_drain_level_calc_type_2(session):
     )
     m4_error = factories.ConnectionNodeFactory(
         exchange_level=1,
-        manhole_bottom_level=2,
+        bottom_level=2,
         exchange_type=constants.CalculationTypeNode.CONNECTED,
     )  # bottom_level  >= drain_level when exchange_type is CONNECTED
     factories.ConnectionNodeFactory(
         exchange_level=1,
-        manhole_bottom_level=0,
+        bottom_level=0,
         exchange_type=constants.CalculationTypeNode.CONNECTED,
     )
     factories.ConnectionNodeFactory(
         exchange_level=None,
-        manhole_bottom_level=0,
+        bottom_level=0,
         exchange_type=constants.CalculationTypeNode.EMBEDDED,
     )
 
     query_drn_lvl_st_bttm_lvl = Query(models.ConnectionNode).filter(
-        models.ConnectionNode.exchange_level
-        < models.ConnectionNode.manhole_bottom_level,
+        models.ConnectionNode.exchange_level < models.ConnectionNode.bottom_level,
         models.ConnectionNode.exchange_type == constants.CalculationTypeNode.CONNECTED,
     )
     query_invalid_not_null = Query(models.ConnectionNode).filter(
@@ -476,9 +475,9 @@ def test_query_check_manhole_drain_level_calc_type_2(session):
         models.ConnectionNode.exchange_level == None,
     )
     check_drn_lvl_gt_bttm_lvl = QueryCheck(
-        column=models.ConnectionNode.manhole_bottom_level,
+        column=models.ConnectionNode.bottom_level,
         invalid=query_drn_lvl_st_bttm_lvl,
-        message="ConnectionNode.exhange_level >= ConnectionNode.manhole_bottom_level when "
+        message="ConnectionNode.exhange_level >= ConnectionNode.bottom_level when "
         "ConnectionNode.exchange_type is CONNECTED",
     )
     check_invalid_not_null = QueryCheck(

--- a/threedi_modelchecker/tests/test_checks_base.py
+++ b/threedi_modelchecker/tests/test_checks_base.py
@@ -271,16 +271,15 @@ def test_type_check_integer(session):
     assert m2.id in invalid_ids
 
 
-@pytest.mark.skip(reason="Needs fixing for schema 227")
 def test_type_check_float_can_store_integer(session):
     if session.bind.name == "postgresql":
         pytest.skip("type checks not working on postgres")
-    factories.ManholeFactory(surface_level=1.3)
-    factories.ManholeFactory(surface_level=None)
-    factories.ManholeFactory(surface_level=1)
-    m1 = factories.ManholeFactory(zoom_category="abc")
+    factories.ChannelFactory(calculation_point_distance=1.3)
+    factories.ChannelFactory(calculation_point_distance=None)
+    factories.ChannelFactory(calculation_point_distance=1)
+    m1 = factories.ChannelFactory(exchange_type="abc")
 
-    type_check = TypeCheck(models.Manhole.zoom_category)
+    type_check = TypeCheck(models.Channel.exchange_type)
     invalid_rows = type_check.get_invalid(session)
     valid_rows = type_check.get_valid(session)
 

--- a/threedi_modelchecker/tests/test_checks_base.py
+++ b/threedi_modelchecker/tests/test_checks_base.py
@@ -109,14 +109,13 @@ def test_unique_check_duplicate_value(session):
     assert dup_channel.id in invalid_ids
 
 
-@pytest.mark.skip(reason="Needs fixing for schema 227")
 def test_unique_check_null_values(session):
-    factories.ManholeFactory.create_batch(
-        5, zoom_category=factory.Sequence(lambda n: n)
+    factories.ChannelFactory.create_batch(
+        5, exchange_type=factory.Sequence(lambda n: n)
     )
-    factories.ManholeFactory.create_batch(3, zoom_category=None)
+    factories.ChannelFactory.create_batch(3, exchange_type=None)
 
-    unique_check = UniqueCheck(models.ConnectionNode.id)
+    unique_check = UniqueCheck(models.Channel.exchange_type)
     invalid_rows = unique_check.get_invalid(session)
     assert len(invalid_rows) == 0
 

--- a/threedi_modelchecker/tests/test_checks_base.py
+++ b/threedi_modelchecker/tests/test_checks_base.py
@@ -87,11 +87,9 @@ def test_fk_check_missing_fk(session):
     assert invalid_rows[0].id == missing_fk.id
 
 
-@pytest.mark.skip(reason="Needs fixing for schema 227")
 def test_unique_check(session):
-    factories.ManholeFactory.create_batch(5)
-
-    unique_check = UniqueCheck(models.Manhole.code)
+    factories.ChannelFactory.create_batch(5)
+    unique_check = UniqueCheck(models.Channel.code)
     invalid_rows = unique_check.get_invalid(session)
     assert len(invalid_rows) == 0
 

--- a/threedi_modelchecker/tests/test_checks_base.py
+++ b/threedi_modelchecker/tests/test_checks_base.py
@@ -94,22 +94,19 @@ def test_unique_check(session):
     assert len(invalid_rows) == 0
 
 
-@pytest.mark.skip(reason="Needs fixing for schema 227")
 def test_unique_check_duplicate_value(session):
-    manholes = factories.ManholeFactory.create_batch(
-        5, zoom_category=factory.Sequence(lambda n: n)
+    channels = factories.ChannelFactory.create_batch(
+        5, exchange_type=factory.Sequence(lambda n: n)
     )
-    duplicate_manhole = factories.ManholeFactory(
-        zoom_category=manholes[0].zoom_category
-    )
+    dup_channel = factories.ChannelFactory(exchange_type=channels[0].exchange_type)
 
-    unique_check = UniqueCheck(models.Manhole.zoom_category)
+    unique_check = UniqueCheck(models.Channel.exchange_type)
     invalid_rows = unique_check.get_invalid(session)
 
     assert len(invalid_rows) == 2
     invalid_ids = [invalid.id for invalid in invalid_rows]
-    assert manholes[0].id in invalid_ids
-    assert duplicate_manhole.id in invalid_ids
+    assert channels[0].id in invalid_ids
+    assert dup_channel.id in invalid_ids
 
 
 @pytest.mark.skip(reason="Needs fixing for schema 227")

--- a/threedi_modelchecker/tests/test_checks_base.py
+++ b/threedi_modelchecker/tests/test_checks_base.py
@@ -289,14 +289,13 @@ def test_type_check_float_can_store_integer(session):
     assert m1.id in invalid_ids
 
 
-@pytest.mark.skip(reason="Needs fixing for schema 227")
 def test_type_check_varchar(session):
     if session.bind.name == "postgresql":
         pytest.skip("type checks not working on postgres")
-    factories.ManholeFactory(code="abc")
-    factories.ManholeFactory(code=123)
+    factories.ChannelFactory(code="abc")
+    factories.ChannelFactory(code=123)
 
-    type_check = TypeCheck(models.Manhole.code)
+    type_check = TypeCheck(models.Channel.code)
     invalid_rows = type_check.get_invalid(session)
 
     assert len(invalid_rows) == 0

--- a/threedi_modelchecker/tests/test_checks_base.py
+++ b/threedi_modelchecker/tests/test_checks_base.py
@@ -242,14 +242,13 @@ def test_run_spatial_function(session):
     q.first()
 
 
-@pytest.mark.skip(reason="Needs fixing for schema 227")
 def test_type_check(session):
     if session.bind.name == "postgresql":
         pytest.skip("type checks not working on postgres")
-    factories.ManholeFactory(zoom_category=123)
-    factories.ManholeFactory(zoom_category=456)
+    factories.ChannelFactory(exchange_type=123)
+    factories.ChannelFactory(exchange_type=456)
 
-    type_check = TypeCheck(models.Manhole.zoom_category)
+    type_check = TypeCheck(models.Channel.exchange_type)
     invalid_rows = type_check.get_invalid(session)
 
     assert len(invalid_rows) == 0

--- a/threedi_modelchecker/tests/test_checks_cross_section_definitions.py
+++ b/threedi_modelchecker/tests/test_checks_cross_section_definitions.py
@@ -336,7 +336,12 @@ def test_check_cross_section_minimum_diameter_tabulated(
 @pytest.mark.parametrize(
     "shape,width,height,expected_result",
     [
-        (constants.CrossSectionShape.CLOSED_RECTANGLE, "0.1", "0.2", 1),  # closed rectangle, fail
+        (
+            constants.CrossSectionShape.CLOSED_RECTANGLE,
+            "0.1",
+            "0.2",
+            1,
+        ),  # closed rectangle, fail
         (constants.CrossSectionShape.RECTANGLE, "0.1", None, 0),  # open rectangle, pass
     ],
 )
@@ -358,7 +363,9 @@ def test_check_cross_section_increasing_open_with_conveyance_friction(
         cross_section_shape=shape,
         friction_type=friction_type,
     )
-    check = OpenIncreasingCrossSectionConveyanceFrictionCheck(column=models.CrossSectionLocation.id)
+    check = OpenIncreasingCrossSectionConveyanceFrictionCheck(
+        column=models.CrossSectionLocation.id
+    )
     # this check should pass on cross-section locations which don't use conveyance,
     # regardless of their other parameters
     if not conveyance:
@@ -405,7 +412,9 @@ def test_check_cross_section_increasing_open_with_conveyance_friction_tabulated(
         cross_section_shape=constants.CrossSectionShape.TABULATED_RECTANGLE,
         friction_type=friction_type,
     )
-    check = OpenIncreasingCrossSectionConveyanceFrictionCheck(column=models.CrossSectionLocation.id)
+    check = OpenIncreasingCrossSectionConveyanceFrictionCheck(
+        column=models.CrossSectionLocation.id
+    )
     # this check should pass on cross-section locations which don't use conveyance,
     # regardless of their other parameters
     if not conveyance:

--- a/threedi_modelchecker/tests/test_checks_cross_section_definitions.py
+++ b/threedi_modelchecker/tests/test_checks_cross_section_definitions.py
@@ -533,7 +533,6 @@ def test_check_friction_values_range(session, friction_types, result):
         ),  # closed tabulated yz,  fail
     ],
 )
-@pytest.mark.skip(reason="broken")
 def test_check_cross_section_increasing_open_with_variables(
     session, cross_section_table, result
 ):

--- a/threedi_modelchecker/tests/test_checks_cross_section_definitions.py
+++ b/threedi_modelchecker/tests/test_checks_cross_section_definitions.py
@@ -17,7 +17,6 @@ from threedi_modelchecker.checks.cross_section_definitions import (
     CrossSectionTableColumnIdx,
     CrossSectionVariableCorrectLengthCheck,
     CrossSectionVariableFrictionRangeCheck,
-    CrossSectionVariableRangeCheck,
     CrossSectionVegetationTableNotNegativeCheck,
     CrossSectionYZCoordinateCountCheck,
     CrossSectionYZHeightCheck,
@@ -491,31 +490,6 @@ def test_cross_section_vegetation_table_not_negative_check(session, table, valid
     )
     invalid_rows = check.get_invalid(session)
     assert (len(invalid_rows) == 0) == valid
-
-
-@pytest.mark.parametrize(
-    "min_value, max_value, left_incl, right_incl, result",
-    [
-        [0, 1, True, True, True],
-        [0, 0.5, True, True, False],
-        [0.5, 1, True, True, False],
-        [0, 1, False, True, False],
-        [0, 1, True, False, False],
-        [0, None, True, True, True],
-        [None, 1, True, True, True],
-    ],
-)
-def test_check_var_range(session, min_value, max_value, left_incl, right_incl, result):
-    factories.CrossSectionLocationFactory(cross_section_friction_values="0 1")
-    check = CrossSectionVariableRangeCheck(
-        column=models.CrossSectionLocation.cross_section_friction_values,
-        min_value=min_value,
-        max_value=max_value,
-        left_inclusive=left_incl,
-        right_inclusive=right_incl,
-    )
-    invalid_rows = check.get_invalid(session)
-    assert (len(invalid_rows) == 0) == result
 
 
 @pytest.mark.parametrize(

--- a/threedi_modelchecker/tests/test_checks_cross_section_definitions.py
+++ b/threedi_modelchecker/tests/test_checks_cross_section_definitions.py
@@ -132,25 +132,25 @@ def test_filter_shapes(session):
     assert len(invalid_rows) == 1
 
 
-@pytest.mark.parametrize(
-    "cross_section_height, is_null, is_empty",
-    [(None, True, False)],
-)
-def test_check_null_check(session, cross_section_height, is_null, is_empty):
-    factories.CrossSectionLocationFactory(
-        cross_section_height=cross_section_height,
-    )
+@pytest.mark.parametrize("val, is_valid", [(None, False), (1, True)])
+def test_check_null_check(session, val, is_valid):
+    factories.CrossSectionLocationFactory(cross_section_height=val)
+    # Check if the invalid row is identified
     check = CrossSectionNullCheck(
         column=models.CrossSectionLocation.cross_section_height
     )
     invalid_rows = check.get_invalid(session)
-    assert (len(invalid_rows) == 1) == is_null
+    assert (len(invalid_rows) == 0) == is_valid
 
+
+@pytest.mark.parametrize("val, is_valid", [(None, True), (1, False)])
+def test_check_expect_empty_check(session, val, is_valid):
+    factories.CrossSectionLocationFactory(cross_section_height=val)
     check = CrossSectionExpectEmptyCheck(
         column=models.CrossSectionLocation.cross_section_height
     )
     invalid_rows = check.get_invalid(session)
-    assert (len(invalid_rows) == 1) == is_empty
+    assert (len(invalid_rows) == 0) == is_valid
 
 
 @pytest.mark.parametrize("width, valid", [(-1, False), (0, False), (1, True)])

--- a/threedi_modelchecker/tests/test_checks_cross_section_definitions.py
+++ b/threedi_modelchecker/tests/test_checks_cross_section_definitions.py
@@ -523,6 +523,7 @@ def test_check_friction_values_range(session, friction_types, result):
         ),  # closed tabulated yz,  fail
     ],
 )
+@pytest.mark.skip(reason="broken")
 def test_check_cross_section_increasing_open_with_variables(
     session, cross_section_table, result
 ):

--- a/threedi_modelchecker/tests/test_checks_cross_section_definitions.py
+++ b/threedi_modelchecker/tests/test_checks_cross_section_definitions.py
@@ -104,27 +104,6 @@ def test_parse_cross_section_vegetation_table(session, vegetation_table, expecte
         assert not values
 
 
-# TODO: remove (?)
-def test_parse_cross_section_table_generator(session):
-    tables = ["0,0\n2,1\n4,2", "0,0\n1,2\n2,4"]
-    expected = [[0, 2, 4], [0, 1, 2]]
-    for cross_section_table in tables:
-        factories.CrossSectionLocationFactory(
-            cross_section_table=cross_section_table,
-        )
-    # can use any class here!
-    check = CrossSectionFloatCheck(
-        column=models.CrossSectionLocation.cross_section_table
-    )
-    for i, (record, values) in enumerate(
-        check.parse_cross_section_table(
-            session=session, col_idx=CrossSectionTableColumnIdx.width
-        )
-    ):
-        if expected:
-            assert values == expected[i]
-
-
 def test_filter_shapes(session):
     # should only check records of given types
     factories.CrossSectionLocationFactory(

--- a/threedi_modelchecker/tests/test_checks_cross_section_definitions.py
+++ b/threedi_modelchecker/tests/test_checks_cross_section_definitions.py
@@ -487,31 +487,27 @@ def test_check_friction_values_range(session, friction_types, result):
 
 
 @pytest.mark.parametrize(
-    "width,height,result",
+    "cross_section_table,result",
     [
         (
-            "0.01 0.11",
-            "0.11 0.21",
+            "0.01,0.11\n0.11,0.21",
             True,
         ),  # open tabulated yz, increasing width, pass
         (
-            "0.11 0.01",
-            "0.11 0.20",
+            "0.11,0.11\n0.01,0.20",
             False,
         ),  # open tabulated yz, decreasing width, fail
         (
-            "0.01 0.11 0.01",
-            "0.11 0.21 0.11",
+            "0.01,0.11\n0.11,0.21\n0.01,0.11",
             False,
         ),  # closed tabulated yz,  fail
     ],
 )
 def test_check_cross_section_increasing_open_with_variables(
-    session, width, height, result
+    session, cross_section_table, result
 ):
     factories.CrossSectionLocationFactory(
-        cross_section_width=width,
-        cross_section_height=height,
+        cross_section_table=cross_section_table,
         cross_section_friction_values="1",
         cross_section_shape=constants.CrossSectionShape.TABULATED_YZ,
     )

--- a/threedi_modelchecker/tests/test_checks_cross_section_definitions.py
+++ b/threedi_modelchecker/tests/test_checks_cross_section_definitions.py
@@ -491,7 +491,7 @@ def test_check_var_range(session, min_value, max_value, left_incl, right_incl, r
 )
 def test_check_friction_values_range(session, friction_types, result):
     factories.CrossSectionLocationFactory(
-        cross_section_friction_values="0 1",
+        cross_section_friction_values="0,1",
         friction_type=constants.FrictionType.MANNING,
     )
     check = CrossSectionVariableFrictionRangeCheck(

--- a/threedi_modelchecker/tests/test_checks_factories.py
+++ b/threedi_modelchecker/tests/test_checks_factories.py
@@ -11,29 +11,26 @@ from threedi_modelchecker.checks.factories import (
 )
 
 
-@pytest.mark.skip(reason="Needs fixing for schema 227")
 def test_gen_foreign_key_checks():
-    foreign_key_checks = generate_foreign_key_checks(models.Manhole.__table__)
+    foreign_key_checks = generate_foreign_key_checks(models.Surface.__table__)
     assert len(foreign_key_checks) == 1
     fk_check = foreign_key_checks[0]
-    assert models.Manhole.connection_node_id == fk_check.column
-    assert models.ConnectionNode.id == fk_check.reference_column
+    assert models.Surface.surface_parameters_id == fk_check.column
+    assert models.SurfaceParameter.id == fk_check.reference_column
 
 
-@pytest.mark.skip(reason="Needs fixing for schema 227")
 def test_gen_not_unique_checks():
-    not_unique_checks = generate_unique_checks(models.Manhole.__table__)
-    assert len(not_unique_checks) == 2
-    assert models.Manhole.id == not_unique_checks[0].column
-    assert models.Manhole.connection_node_id == not_unique_checks[1].column
+    not_unique_checks = generate_unique_checks(models.Channel.__table__)
+    assert len(not_unique_checks) == 1
+    assert models.Channel.id == not_unique_checks[0].column
 
 
-@pytest.mark.skip(reason="Needs fixing for schema 227")
 def test_gen_not_null_checks():
-    not_null_checks = generate_not_null_checks(models.Manhole.__table__)
-    assert len(not_null_checks) == 3
+    not_null_checks = generate_not_null_checks(models.Channel.__table__)
+    assert len(not_null_checks) == 2
     not_null_check_columns = [check.column for check in not_null_checks]
-    assert models.Manhole.id in not_null_check_columns
+    assert models.Channel.id in not_null_check_columns
+    assert models.Channel.geom in not_null_check_columns
 
 
 def test_gen_geometry_check():

--- a/threedi_modelchecker/tests/test_checks_factories.py
+++ b/threedi_modelchecker/tests/test_checks_factories.py
@@ -25,12 +25,22 @@ def test_gen_not_unique_checks():
     assert models.Channel.id == not_unique_checks[0].column
 
 
-def test_gen_not_null_checks():
-    not_null_checks = generate_not_null_checks(models.Channel.__table__)
-    assert len(not_null_checks) == 2
+@pytest.mark.parametrize(
+    "extra_columns", [None, [], [models.Channel.connection_node_id_end]]
+)
+def test_gen_not_null_checks(extra_columns):
+    not_null_checks = generate_not_null_checks(
+        models.Channel.__table__, extra_not_null_columns=extra_columns
+    )
+    if extra_columns is None:
+        extra_columns = []
+    assert len(not_null_checks) == 2 + len(extra_columns)
     not_null_check_columns = [check.column for check in not_null_checks]
     assert models.Channel.id in not_null_check_columns
     assert models.Channel.geom in not_null_check_columns
+    for col in extra_columns:
+        assert col in not_null_check_columns
+    assert models.Channel.code not in not_null_check_columns
 
 
 def test_gen_geometry_check():

--- a/threedi_modelchecker/tests/test_checks_other.py
+++ b/threedi_modelchecker/tests/test_checks_other.py
@@ -200,12 +200,12 @@ def test_channel_manhole_level_check(
     factories.ConnectionNodeFactory(
         id=1,
         geom=f"SRID=4326;POINT({starting_coordinates})",
-        manhole_bottom_level=manhole_level,
+        bottom_level=manhole_level,
     )
     factories.ConnectionNodeFactory(
         id=2,
         geom=f"SRID=4326;POINT({ending_coordinates})",
-        manhole_bottom_level=manhole_level,
+        bottom_level=manhole_level,
     )
     factories.ChannelFactory(
         id=1,

--- a/threedi_modelchecker/tests/test_checks_other.py
+++ b/threedi_modelchecker/tests/test_checks_other.py
@@ -7,7 +7,7 @@ from threedi_schema import constants, models, ThreediDatabase
 from threedi_schema.beta_features import BETA_COLUMNS, BETA_VALUES
 
 from threedi_modelchecker.checks.other import (
-    AllPresentFixedVegetationParameters,
+    AllPresentVegetationParameters,
     BetaColumnsCheck,
     BetaValuesCheck,
     ChannelManholeLevelCheck,
@@ -806,7 +806,7 @@ def test_all_present_fixed_vegetation_parameters(
         friction_type=friction_type,
         **veg_args,
     )
-    check = AllPresentFixedVegetationParameters(
+    check = AllPresentVegetationParameters(
         column=models.CrossSectionLocation.vegetation_height
     )
     invalid_rows = check.get_invalid(session)

--- a/threedi_modelchecker/tests/test_checks_other.py
+++ b/threedi_modelchecker/tests/test_checks_other.py
@@ -151,7 +151,7 @@ def test_open_channels_with_nested_newton(session):
     factories.CrossSectionLocationFactory(
         channel_id=1,
         cross_section_shape=constants.CrossSectionShape.TABULATED_TRAPEZIUM,
-        cross_section_table="1,0\n0,1",
+        cross_section_table="0,1\n1,0",
         geom="SRID=4326;POINT(-71.0645 42.287)",
     )
     factories.ChannelFactory(

--- a/threedi_modelchecker/tests/test_checks_other.py
+++ b/threedi_modelchecker/tests/test_checks_other.py
@@ -137,44 +137,35 @@ def test_connection_nodes_length_missing_end_node(session):
     assert len(errors) == 0
 
 
-@pytest.mark.skip(reason="Needs fixing for schema 227")
 def test_open_channels_with_nested_newton(session):
     factories.NumericalSettingsFactory(use_nested_newton=0)
     factories.ConnectionNodeFactory(id=1, geom="SRID=4326;POINT(-71.064544 42.28787)")
     factories.ConnectionNodeFactory(id=2, geom="SRID=4326;POINT(-71.0645 42.287)")
-    channel = factories.ChannelFactory(
+    factories.ChannelFactory(
+        id=1,
         connection_node_id_start=1,
         connection_node_id_end=2,
         geom="SRID=4326;LINESTRING(-71.064544 42.28787, -71.0645 42.287)",
     )
-    open_definition = factories.CrossSectionDefinitionFactory(
-        shape=constants.CrossSectionShape.TABULATED_TRAPEZIUM, width="1 0"
-    )
     factories.CrossSectionLocationFactory(
-        channel=channel,
-        definition=open_definition,
+        channel_id=1,
+        cross_section_shape=constants.CrossSectionShape.TABULATED_TRAPEZIUM,
+        cross_section_table="1,0\n0,1",
         geom="SRID=4326;POINT(-71.0645 42.287)",
     )
-
-    channel2 = factories.ChannelFactory(
-        connection_node_start=factories.ConnectionNodeFactory(
-            geom="SRID=4326;POINT(-71.064544 42.28787)"
-        ),
-        connection_node_end=factories.ConnectionNodeFactory(
-            geom="SRID=4326;POINT(-71.0645 42.287)"
-        ),
+    factories.ChannelFactory(
+        id=2,
+        connection_node_id_start=1,
+        connection_node_id_end=2,
         geom="SRID=4326;LINESTRING(-71.064544 42.28787, -71.0645 42.287)",
     )
-    open_definition_egg = factories.CrossSectionDefinitionFactory(
-        shape=constants.CrossSectionShape.EGG,
-    )
     factories.CrossSectionLocationFactory(
-        channel=channel2,
-        definition=open_definition_egg,
+        channel_id=2,
         geom="SRID=4326;POINT(-71.0645 42.287)",
+        cross_section_shape=constants.CrossSectionShape.EGG,
     )
 
-    check = OpenChannelsWithNestedNewton(table=models.CrossSectionLocation)
+    check = OpenChannelsWithNestedNewton(column=models.CrossSectionLocation.id)
 
     errors = check.get_invalid(session)
     assert len(errors) == 2

--- a/threedi_modelchecker/tests/test_checks_other.py
+++ b/threedi_modelchecker/tests/test_checks_other.py
@@ -174,7 +174,7 @@ def test_open_channels_with_nested_newton(session):
         geom="SRID=4326;POINT(-71.0645 42.287)",
     )
 
-    check = OpenChannelsWithNestedNewton()
+    check = OpenChannelsWithNestedNewton(table=models.CrossSectionLocation)
 
     errors = check.get_invalid(session)
     assert len(errors) == 2
@@ -583,7 +583,6 @@ def test_connection_node_mapped_surfaces(
     assert len(invalid) == expected_result
 
 
-@pytest.mark.skip(reason="Needs fixing for schema 227")
 @pytest.mark.parametrize(
     "configuration,expected_result",
     [
@@ -596,11 +595,8 @@ def test_feature_closed_cross_section(session, configuration, expected_result):
         shape = constants.CrossSectionShape.CLOSED_RECTANGLE
     else:
         shape = constants.CrossSectionShape.RECTANGLE
-    cross_section_definition = factories.CrossSectionDefinitionFactory(
-        shape=shape, height=1, width=1
-    )
-    factories.CulvertFactory(cross_section_definition=cross_section_definition)
-    check = FeatureClosedCrossSectionCheck(models.Culvert.id)
+    factories.CrossSectionLocationFactory(cross_section_shape=shape, cross_section_width=1, cross_section_height=1)
+    check = FeatureClosedCrossSectionCheck(models.CrossSectionLocation.id)
     invalid = check.get_invalid(session)
     assert len(invalid) == expected_result
 

--- a/threedi_modelchecker/tests/test_checks_other.py
+++ b/threedi_modelchecker/tests/test_checks_other.py
@@ -595,7 +595,9 @@ def test_feature_closed_cross_section(session, configuration, expected_result):
         shape = constants.CrossSectionShape.CLOSED_RECTANGLE
     else:
         shape = constants.CrossSectionShape.RECTANGLE
-    factories.CrossSectionLocationFactory(cross_section_shape=shape, cross_section_width=1, cross_section_height=1)
+    factories.CrossSectionLocationFactory(
+        cross_section_shape=shape, cross_section_width=1, cross_section_height=1
+    )
     check = FeatureClosedCrossSectionCheck(models.CrossSectionLocation.id)
     invalid = check.get_invalid(session)
     assert len(invalid) == expected_result

--- a/threedi_modelchecker/tests/test_checks_other.py
+++ b/threedi_modelchecker/tests/test_checks_other.py
@@ -188,7 +188,6 @@ channel_manhole_level_testdata = [
 ]
 
 
-@pytest.mark.skip(reason="Needs fixing for schema 227")
 @pytest.mark.parametrize(
     "manhole_location,starting_reference_level,ending_reference_level,manhole_level,errors_number",
     channel_manhole_level_testdata,
@@ -206,33 +205,33 @@ def test_channel_manhole_level_check(
     # use nested factories for channel and connectionNode
     starting_coordinates = "4.718300 52.696686"
     ending_coordinates = "4.718255 52.696709"
-    start_node = factories.ConnectionNodeFactory(
-        geom=f"SRID=4326;POINT({starting_coordinates})"
+    factories.ConnectionNodeFactory(
+        id=1,
+        geom=f"SRID=4326;POINT({starting_coordinates})",
+        manhole_bottom_level=manhole_level,
     )
-    end_node = factories.ConnectionNodeFactory(
-        geom=f"SRID=4326;POINT({ending_coordinates})"
+    factories.ConnectionNodeFactory(
+        id=2,
+        geom=f"SRID=4326;POINT({ending_coordinates})",
+        manhole_bottom_level=manhole_level,
     )
-    channel = factories.ChannelFactory(
+    factories.ChannelFactory(
+        id=1,
         geom=f"SRID=4326;LINESTRING({starting_coordinates}, {ending_coordinates})",
-        connection_node_start=start_node,
-        connection_node_end=end_node,
+        connection_node_id_start=1,
+        connection_node_id_end=2,
     )
     # starting cross-section location
     factories.CrossSectionLocationFactory(
         geom="SRID=4326;POINT(4.718278 52.696697)",
         reference_level=starting_reference_level,
-        channel=channel,
+        channel_id=1,
     )
     # ending cross-section location
     factories.CrossSectionLocationFactory(
         geom="SRID=4326;POINT(4.718264 52.696704)",
         reference_level=ending_reference_level,
-        channel=channel,
-    )
-    # manhole
-    factories.ManholeFactory(
-        connection_node=end_node if manhole_location == "end" else start_node,
-        bottom_level=manhole_level,
+        channel_id=1,
     )
     check = ChannelManholeLevelCheck(nodes_to_check=manhole_location)
     errors = check.get_invalid(session)

--- a/threedi_modelchecker/tests/test_checks_other.py
+++ b/threedi_modelchecker/tests/test_checks_other.py
@@ -486,7 +486,7 @@ def test_spatial_index_ok(session):
 
 def test_spatial_index_disabled(empty_sqlite_v4):
     session = empty_sqlite_v4.get_session()
-    session.execute(text("SELECT DisableSpatialIndex('v2_connection_nodes', 'geom')"))
+    session.execute(text("SELECT DisableSpatialIndex('connection_nodes', 'geom')"))
     check = SpatialIndexCheck(models.ConnectionNode.geom)
     invalid = check.get_invalid(session)
     assert len(invalid) == 1

--- a/threedi_modelchecker/tests/test_checks_other.py
+++ b/threedi_modelchecker/tests/test_checks_other.py
@@ -584,17 +584,13 @@ def test_connection_node_mapped_surfaces(
 
 
 @pytest.mark.parametrize(
-    "configuration,expected_result",
+    "shape,expected_result",
     [
-        ("closed", 0),
-        ("open", 1),
+        (constants.CrossSectionShape.CLOSED_RECTANGLE, 0),
+        (constants.CrossSectionShape.RECTANGLE, 1),
     ],
 )
-def test_feature_closed_cross_section(session, configuration, expected_result):
-    if configuration == "closed":
-        shape = constants.CrossSectionShape.CLOSED_RECTANGLE
-    else:
-        shape = constants.CrossSectionShape.RECTANGLE
+def test_feature_closed_cross_section(session, shape, expected_result):
     factories.CrossSectionLocationFactory(
         cross_section_shape=shape, cross_section_width=1, cross_section_height=1
     )


### PR DESCRIPTION
First of all apologies to the reviewer for the size of this PR. This could have been handled better with smaller PRs on a feature branch; but hindsight is 20 20. I made an overview below, but it's probably best to review together.

## Overview of schema changes that had major effects

### Removal of `CrossSectionDefinition`

The `CrossSectionDefinition` was moved to linked tables: `CrossSectionLocation`, `Culvert', `Orifice`, `Pipe`, `Weir`. Therefore, all checks related to `CrossSectionDefinition` had to be modified an many checks for `CrossSectionLocation` had to be extended to the other four tables.

### Cross section parameters

Several cross section parameters were moved or reformatted:

* `cross_section_width` and `cross_section_height` now only contain a single float. In case of a tabulated shape, the height and width (or Y and Z) are in a csv table in `cross_section_table`. 
* `vegetation_stem_densities`, `vegetation_stem_diameters`, `vegetation_heights` and `vegetation_drag_coefficients`, are removed and that data is now in `cross_section_vegetation_table` (vegetation_stem_densities, vegetation_stem_diameters, vegetation_heights, vegetation_drag_coefficients)
* `cross_section_friction_values` containts a comma separated list of friction values

For fields that changed from string to float, a number of checks could be removed. For the new comma separated fields, checks are added to ensure their formatting.

#### Added basic functions

All parameters for tabulated cross sections are formatted as one or more lines of comma separated values and can be easily parsed with `parse_csv_table_col` and `parse_csv_table`. 

#### Iterating over `cross_section_table` or `cross_section_vegetation_table` records

`CrossSectionBaseCheck` is extended with two iterators: `parse_cross_section_table` and `parse_cross_section_vegetation_table` that enable iterating over these columns. They return the parsed data and the full record.

#### Modified cross section configuration identification

I split `cross_section_configuration` in two, one for tabulated and one for not tabulated, and added wrapper `cross_section_configuration_for_record`. For tabulated shapes, widths and heights are retrieved with `get_widths_heights_for_tabulated_record` which takes into consideration the shape, because the formatting of `cross_section_table` differs between `TABULATED_YZ` and the other tabulated shapes. I extended `constants.CrossSectionShape` (in threedi-schema) with `is_tabulated` and  `is_open` to make all this easier.

The new functions used for cross section configuration identification are all included in the tests. This reduces the number of test cases required for testing checks that depend on the corss section configuration.


