### PR TITLE
Fix typos when referring to epsg_ref_name and epsg_ref_code

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog of threedi-modelchecker
 2.17.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix typos in session.epsg_ref_name and session.epsg_ref_code
+- Ensure that id's created via factory models, used for testing, always autoincrement
+
 
 
 2.17.0 (2025-01-24)

--- a/threedi_modelchecker/checks/base.py
+++ b/threedi_modelchecker/checks/base.py
@@ -422,17 +422,17 @@ class EPSGGeomCheck(BaseCheck):
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
-        self.ref_epsg_name = ""
+        self.epsg_ref_name = ""
 
     def get_invalid(self, session: Session) -> List[NamedTuple]:
-        self.ref_epsg_name = session.ref_epsg_name
-        if session.ref_epsg_code is None:
+        self.epsg_ref_name = session.epsg_ref_name
+        if session.epsg_ref_code is None:
             return []
         return (
             self.to_check(session)
-            .filter(ST_SRID(self.column) != session.ref_epsg_code)
+            .filter(ST_SRID(self.column) != session.epsg_ref_code)
             .all()
         )
 
     def description(self) -> str:
-        return f"The epsg of {self.table.name}.{self.column_name} should match {self.ref_epsg_name}"
+        return f"The epsg of {self.table.name}.{self.column_name} should match {self.epsg_ref_name}"

--- a/threedi_modelchecker/checks/other.py
+++ b/threedi_modelchecker/checks/other.py
@@ -1127,7 +1127,7 @@ class ModelEPSGCheckValid(BaseCheck):
         self.epsg_code = None
 
     def get_invalid(self, session: Session) -> List[NamedTuple]:
-        self.epsg_code = session.ref_epsg_code
+        self.epsg_code = session.epsg_ref_code
         if self.epsg_code is not None:
             try:
                 pyproj.CRS.from_epsg(self.epsg_code)
@@ -1145,7 +1145,7 @@ class ModelEPSGCheckProjected(BaseCheck):
         self.epsg_code = None
 
     def get_invalid(self, session: Session) -> List[NamedTuple]:
-        self.epsg_code = session.ref_epsg_code
+        self.epsg_code = session.epsg_ref_code
         if self.epsg_code is not None:
             try:
                 crs = pyproj.CRS.from_epsg(self.epsg_code)
@@ -1166,7 +1166,7 @@ class ModelEPSGCheckUnits(BaseCheck):
         self.epsg_code = None
 
     def get_invalid(self, session: Session) -> List[NamedTuple]:
-        self.epsg_code = session.ref_epsg_code
+        self.epsg_code = session.epsg_ref_code
         if self.epsg_code is not None:
             try:
                 crs = pyproj.CRS.from_epsg(self.epsg_code)

--- a/threedi_modelchecker/checks/raster.py
+++ b/threedi_modelchecker/checks/raster.py
@@ -150,28 +150,28 @@ class RasterHasMatchingEPSGCheck(BaseRasterCheck):
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
-        self.ref_epsg_name = ""
-        self.ref_epsg_code = None
+        self.epsg_ref_name = ""
+        self.epsg_ref_code = None
 
     def get_invalid(self, session):
-        if session.ref_epsg_code is None:
+        if session.epsg_ref_code is None:
             return []
-        self.ref_epsg_name = session.ref_epsg_name
-        self.ref_epsg_code = session.ref_epsg_code
+        self.epsg_ref_name = session.epsg_ref_name
+        self.epsg_ref_code = session.epsg_ref_code
         return super().get_invalid(session)
 
     def is_valid(self, path: str, interface_cls: Type[RasterInterface]):
-        if self.ref_epsg_code is None:
+        if self.epsg_ref_code is None:
             return True
         with interface_cls(path) as raster:
             if not raster.is_valid_geotiff or not raster.has_projection:
                 return True
             if raster.epsg_code is None:
                 return False
-            return raster.epsg_code == self.ref_epsg_code
+            return raster.epsg_code == self.epsg_ref_code
 
     def description(self):
-        return f"The file in {self.column_name} has no EPSG code or the EPSG code does not match does not match {self.ref_epsg_name}"
+        return f"The file in {self.column_name} has no EPSG code or the EPSG code does not match does not match {self.epsg_ref_name}"
 
 
 class RasterSquareCellsCheck(BaseRasterCheck):

--- a/threedi_modelchecker/tests/factories.py
+++ b/threedi_modelchecker/tests/factories.py
@@ -24,7 +24,7 @@ class BaseFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         abstract = True
 
-    id = factory.Faker("random_int")
+    id = factory.Sequence(lambda n: n + 1)
 
 
 class TimeStepSettingsFactory(BaseFactory):

--- a/threedi_modelchecker/tests/test_checks_base.py
+++ b/threedi_modelchecker/tests/test_checks_base.py
@@ -603,8 +603,8 @@ def test_list_of_inst_check(session, tag_ids_string, nof_invalid_expected):
 )
 def test_epsg_geom_check(session, ref_epsg, valid):
     factories.ConnectionNodeFactory()
-    session.ref_epsg_code = ref_epsg
-    session.ref_epsg_name = "foo"
+    session.epsg_ref_code = ref_epsg
+    session.epsg_ref_name = "foo"
     check = EPSGGeomCheck(column=models.ConnectionNode.geom)
     invalids = check.get_invalid(session)
     assert (len(invalids) == 0) == valid

--- a/threedi_modelchecker/tests/test_checks_other.py
+++ b/threedi_modelchecker/tests/test_checks_other.py
@@ -937,7 +937,7 @@ def test_dwf_distribution_sum_check(session, distribution, valid):
 )
 def test_model_epsg_check_valid(session, ref_epsg, valid):
     factories.ModelSettingsFactory()
-    session.ref_epsg_code = ref_epsg
+    session.epsg_ref_code = ref_epsg
     check = ModelEPSGCheckValid()
     invalids = check.get_invalid(session)
     assert (len(invalids) == 0) == valid
@@ -953,7 +953,7 @@ def test_model_epsg_check_valid(session, ref_epsg, valid):
 )
 def test_model_epsg_check_projected(session, ref_epsg, valid):
     factories.ModelSettingsFactory()
-    session.ref_epsg_code = ref_epsg
+    session.epsg_ref_code = ref_epsg
     check = ModelEPSGCheckProjected()
     invalids = check.get_invalid(session)
     assert (len(invalids) == 0) == valid
@@ -969,7 +969,7 @@ def test_model_epsg_check_projected(session, ref_epsg, valid):
 )
 def test_model_epsg_check_units(session, ref_epsg, valid):
     factories.ModelSettingsFactory()
-    session.ref_epsg_code = ref_epsg
+    session.epsg_ref_code = ref_epsg
     check = ModelEPSGCheckUnits()
     invalids = check.get_invalid(session)
     assert (len(invalids) == 0) == valid

--- a/threedi_modelchecker/tests/test_checks_raster.py
+++ b/threedi_modelchecker/tests/test_checks_raster.py
@@ -254,7 +254,7 @@ NULL_EPSG_CODE = (
 def test_has_epsg(tmp_path, interface_cls, raster_epsg, sqlite_epsg, validity):
     path = create_geotiff(tmp_path / "raster.tiff", epsg=raster_epsg)
     check = RasterHasMatchingEPSGCheck(column=models.ModelSettings.dem_file)
-    check.ref_epsg_code = sqlite_epsg
+    check.epsg_ref_code = sqlite_epsg
     assert check.is_valid(path, interface_cls) == validity
 
 

--- a/threedi_modelchecker/tests/test_checks_timeseries.py
+++ b/threedi_modelchecker/tests/test_checks_timeseries.py
@@ -40,11 +40,11 @@ def test_timeseries_same_timesteps(
 ):
     if check_type == "1d":
         for i, timeseries in enumerate(timeseries_tuple):
-            BoundaryConditions1DFactory(id=i, timeseries=timeseries)
+            BoundaryConditions1DFactory(timeseries=timeseries)
         check = TimeSeriesEqualTimestepsCheck(models.BoundaryCondition1D.timeseries)
     elif check_type == "2d":
         for i, timeseries in enumerate(timeseries_tuple):
-            BoundaryConditions2DFactory(id=i, timeseries=timeseries)
+            BoundaryConditions2DFactory(timeseries=timeseries)
         check = TimeSeriesEqualTimestepsCheck(models.BoundaryConditions2D.timeseries)
     invalid = check.get_invalid(session)
     assert len(invalid) == expected_invalid
@@ -81,9 +81,9 @@ def test_first_timeseries_same_timesteps(
     session, one_d_timeseries_tuple, two_d_timeseries_tuple, expected_invalid
 ):
     for i, timeseries in enumerate(one_d_timeseries_tuple):
-        BoundaryConditions1DFactory(id=i, timeseries=timeseries)
+        BoundaryConditions1DFactory(timeseries=timeseries)
     for i, timeseries in enumerate(two_d_timeseries_tuple):
-        BoundaryConditions2DFactory(id=i, timeseries=timeseries)
+        BoundaryConditions2DFactory(timeseries=timeseries)
     check = FirstTimeSeriesEqualTimestepsCheck()
     invalid = check.get_invalid(session)
     assert len(invalid) == expected_invalid


### PR DESCRIPTION
A whole bunch of references to `session.epsg_ref_name` and `session.epsg_ref_code` were incorrect. It worries me a bit that this is not covered by the tests, but that should be fixed later.