### PR TITLE
processed review comments from Nici for modelchecker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,17 +2,17 @@ default_language_version:
   python: python3
 repos:
 - repo: https://github.com/pycqa/isort
-  rev: '5.12.0'
+  rev: '6.0.0'
   hooks:
   - id: isort
     exclude: 'settings'
 - repo: https://github.com/psf/black
-  rev: '22.8.0'
+  rev: '25.1.0'
   hooks:
   - id: black
     exclude: 'migrations*|urls*|settings*|setup.py'
 - repo: https://github.com/pycqa/flake8
-  rev: '3.9.2'
+  rev: '7.1.1'
   hooks:
   - id: flake8
     # NB The "exclude" setting in setup.cfg is ignored by pre-commit

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ Changelog of threedi-modelchecker
 2.17.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Check with error_code=46 has become FUTURE_ERROR
+- Check with error_code=800 has become FUTURE_ERROR
+- Removed checks: 28, 186, 1601, 1602, 1603. Can be re-added at a later stage.
+- Checks with error_code in [95, 96, 97] are not only run for channels.
+- Some textual fixes.
 
 
 2.17.2 (2025-01-31)
@@ -481,7 +485,7 @@ Changelog of threedi-modelchecker
 -----------------
 
 - Added raster checks: file validity, has one band, has crs, range check.
-  For DEM only it is also checked if pixels are square and crs is projected. 
+  For DEM only it is also checked if pixels are square and crs is projected.
 
 - Added warning 325: interception_file given and interception_global not.
 
@@ -628,7 +632,7 @@ Changelog of threedi-modelchecker
 
 - Updated DWF calculation to match ThreediToolBox update.
 
-- Included Surface in DWF calculation. 
+- Included Surface in DWF calculation.
 
 
 0.24.2 (2022-01-18)
@@ -765,13 +769,13 @@ Changelog of threedi-modelchecker
 0.17 (2021-11-03)
 -----------------
 
-- Added `id` (boundary sqlite id)  and `type` (1D or 2D)  field to generated boundaries JSON file. 
+- Added `id` (boundary sqlite id)  and `type` (1D or 2D)  field to generated boundaries JSON file.
 
 
 0.16 (2021-11-02)
 -----------------
 
-- Added support for saving 1D initial waterlevel (from file), 2D initial waterlevel and initial groundwaterlevel in API. 
+- Added support for saving 1D initial waterlevel (from file), 2D initial waterlevel and initial groundwaterlevel in API.
   Note: uses first initial waterlevel (aggregation) resource found for 1D, 2D or groundwater.
 
 0.15 (2021-10-25)
@@ -828,7 +832,7 @@ Changelog of threedi-modelchecker
 - Set WARNING in description of check on storage area of an isolated manhole.
 
 - Added database schema revision management using alembic. The ModelSchema has
-  two new methods: .get_version() and .upgrade(). 
+  two new methods: .get_version() and .upgrade().
 
 
 0.11 (2021-01-26)
@@ -939,7 +943,7 @@ Changelog of threedi-modelchecker
 - Updated some constraints on CrossSectionShapeCheck:
   - Heights of tabulated shape must be increasing.
   - Egg only requires a width, which must be greater than 0.
-- Added 0 to a valid value for ZoomCategories. Also renamed the ZoomCategories names 
+- Added 0 to a valid value for ZoomCategories. Also renamed the ZoomCategories names
   to something clear names.
 
 
@@ -947,7 +951,7 @@ Changelog of threedi-modelchecker
 ----------------
 
 - Renamed some methods of ThreediModelChecker.
-- Added basic to the 3di model schema: checks if the model has the latest migration 
+- Added basic to the 3di model schema: checks if the model has the latest migration
   applied and raises an error if not.
 - Rewrote CrossSectionShape check to no longer use regex and added it to config.
 

--- a/threedi_modelchecker/checks/cross_section_definitions.py
+++ b/threedi_modelchecker/checks/cross_section_definitions.py
@@ -191,7 +191,7 @@ class CrossSectionTableCheck(CrossSectionCSVFormatCheck):
 
     def description(self):
         return (
-            f"{self.table.name}.{self.column_name} should contain a csv table containing "
+            f"{self.column_name} should contain a csv table containing "
             f"{self.ncol} columns with floats for shapes {self.shape_msg}"
         )
 
@@ -543,7 +543,7 @@ class CrossSectionVariableCorrectLengthCheck(CrossSectionBaseCheck, ABC):
         return invalids
 
     def description(self):
-        return f"{self.column_name} should contain 1 value for each element; len({self.column_name}) = len(width)-1"
+        return f"{self.column_name} should contain 1 value for each element."
 
 
 class OpenIncreasingCrossSectionConveyanceFrictionCheckWithMaterial(

--- a/threedi_modelchecker/checks/other.py
+++ b/threedi_modelchecker/checks/other.py
@@ -330,10 +330,10 @@ class ConnectionNodesDistance(BaseCheck):
                 SELECT ROWID
                 FROM rtree_connection_node_geom
                 WHERE (
-                    maxx >= ST_MinX(ST_Buffer(cn1.geom, {self.minimum_distance/2}))
-                    AND minx <= ST_MaxX(ST_Buffer(cn1.geom, {self.minimum_distance/2}))
-                    AND maxy >= ST_MinY(ST_Buffer(cn1.geom, {self.minimum_distance/2}))
-                    AND miny <= ST_MaxY(ST_Buffer(cn1.geom, {self.minimum_distance/2}))
+                    maxx >= ST_MinX(ST_Buffer(cn1.geom, {self.minimum_distance / 2}))
+                    AND minx <= ST_MaxX(ST_Buffer(cn1.geom, {self.minimum_distance / 2}))
+                    AND maxy >= ST_MinY(ST_Buffer(cn1.geom, {self.minimum_distance / 2}))
+                    AND miny <= ST_MaxY(ST_Buffer(cn1.geom, {self.minimum_distance / 2}))
                 )
             )
             """
@@ -344,7 +344,7 @@ class ConnectionNodesDistance(BaseCheck):
     def description(self) -> str:
 
         return (
-            f"The connection_node is within {self.minimum_distance * 100 } cm of "
+            f"The connection_node is within {self.minimum_distance * 100} cm of "
             f"another connection_node."
         )
 
@@ -423,7 +423,7 @@ class ChannelManholeLevelCheck(BaseCheck):
     def description(self) -> str:
         return (
             f"The connection_node.bottom_level at the {self.nodes_to_check} of this channel is higher than the "
-            "cross_section_location.reference_level closest to the manhole. This will be "
+            "cross_section_location.reference_level closest to the connection-node. This will be "
             "automatically fixed in threedigrid-builder."
         )
 
@@ -1118,7 +1118,9 @@ class DWFDistributionSumCheck(DWFDistributionBaseCheck):
         return invalids
 
     def description(self) -> str:
-        return f"The values in {self.table.name}.{self.column_name} should add up to"
+        return (
+            f"The values in {self.table.name}.{self.column_name} should add up to 100 %"
+        )
 
 
 class ModelEPSGCheckValid(BaseCheck):


### PR DESCRIPTION
# Checks level aanpassen
46 -> FUTURE_ERROR
800 -> FUTURE_ERROR (speciaal voor Olof zijn geheugen)

# Check weghalen
- 28 
- 186
- 1601
- 1602
- 1603


# Divers
- 24/25 -> gelden niet meer als 1601-1603 waar zijn. (relationele checks)
- 80 -> spatie in de text (description)
- 87 -> description {self.table.name} kan wel weg.
 109 -> manhole bestaat niet meer -> connectionnode
- 623 -> add up to 100 %
- 181, 196 -> na ";" kan weg
- 95/96/97 -> voor culvert, orfice, pipes, weir mag er geen YZ profile worden gezet. (alleen bij channels wel)

