### PR TITLE
Add exporter that includes geometry related to error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog of threedi-modelchecker
 2.17.15 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Add exporter that includes geometries
 
 
 2.17.14 (2025-04-03)

--- a/threedi_modelchecker/exporters.py
+++ b/threedi_modelchecker/exporters.py
@@ -1,8 +1,14 @@
 import csv
+from collections import namedtuple
 from io import StringIO
-from typing import NamedTuple
+from typing import Iterator, NamedTuple, Tuple
 
 from threedi_modelchecker.checks.base import BaseCheck
+
+ErrorWithGeom = namedtuple(
+    "ErrorWithGeom",
+    ["name", "code", "id", "table", "column", "value", "description", "geom"],
+)
 
 
 # error handling export functions
@@ -28,6 +34,31 @@ def export_to_file(errors, file):
     with open(file, "w") as f:
         for error in errors:
             f.write(format_check_results(*error) + "\n")
+
+
+def export_with_geom(
+    errors: Iterator[Tuple[BaseCheck, NamedTuple]],
+) -> list[ErrorWithGeom]:
+    """Process errors into a list that includes the geometry related to the error
+
+    :param errors: iterator of BaseModelError
+    :return: A list of ErrorWithGeom named tuples, each containing details about the error,
+    including geometry if available
+    """
+    # TODO: test this!!!!
+    return [
+        ErrorWithGeom(
+            name=check.level.name,
+            code=check.error_code,
+            id=error_row.id,
+            table=check.table.name,
+            column=check.column.name,
+            value=getattr(error_row, check.column.name),
+            description=check.description(),
+            geom=error_row.geom.as_wkb() if hasattr(error_row, "geom") else None,
+        )
+        for check, error_row in errors
+    ]
 
 
 def format_check_results(check: BaseCheck, invalid_row: NamedTuple):

--- a/threedi_modelchecker/exporters.py
+++ b/threedi_modelchecker/exporters.py
@@ -45,7 +45,6 @@ def export_with_geom(
     :return: A list of ErrorWithGeom named tuples, each containing details about the error,
     including geometry if available
     """
-    # TODO: test this!!!!
     return [
         ErrorWithGeom(
             name=check.level.name,

--- a/threedi_modelchecker/tests/test_exporters.py
+++ b/threedi_modelchecker/tests/test_exporters.py
@@ -1,8 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-from geoalchemy2.shape import from_shape
-from shapely import wkt
 
 from threedi_modelchecker.checks.base import CheckLevel
 from threedi_modelchecker.exporters import (
@@ -88,11 +86,11 @@ def test_export_with_geom(fake_check_error):
     del error_row_no_geom.geom
     error_row_no_geom.foo = "bar"
     error_row_geom = MagicMock()
-    ref_geom = wkt.loads("POINT(1 1)")
-    error_row_geom.geom = from_shape(ref_geom, srid=4326)
+    # mock as_wkb to test the return without depending on shapely
+    error_row_geom.geom.as_wkb = MagicMock(return_value="wkb")
     error_row_geom.foo = "bar"
     result = export_with_geom(
         [(fake_check_error, error_row_no_geom), (fake_check_error, error_row_geom)]
     )
     assert result[0].geom is None
-    assert bytes(result[1].geom.data) == ref_geom.wkb
+    assert result[1].geom == "wkb"

--- a/threedi_modelchecker/tests/test_exporters.py
+++ b/threedi_modelchecker/tests/test_exporters.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 import pytest
 
 from threedi_modelchecker.checks.base import CheckLevel
@@ -5,22 +7,41 @@ from threedi_modelchecker.exporters import generate_csv_table, generate_rst_tabl
 
 
 @pytest.fixture
-def fake_checks():
-    class FakeCheck:
-        def __init__(self, level, error_code):
-            self.level = level
-            self.error_code = error_code
+def fake_check_warning():
+    fake_check = MagicMock()
+    fake_check.level = CheckLevel.WARNING
+    fake_check.error_code = 2
+    fake_check.description.return_value = (
+        "This sample message has code 2 and level WARNING"
+    )
+    return fake_check
 
-        def description(self):
-            return f"This sample message has code {self.error_code} and level {self.level.name}"
 
-    fake_checks = [
-        FakeCheck(level=CheckLevel.WARNING, error_code=2),
-        FakeCheck(level=CheckLevel.ERROR, error_code=1234),
-        FakeCheck(level=CheckLevel.INFO, error_code=12),
-    ]
+@pytest.fixture
+def fake_check_error():
+    fake_check = MagicMock()
+    fake_check.level = CheckLevel.ERROR
+    fake_check.error_code = 1234
+    fake_check.description.return_value = (
+        "This sample message has code 1234 and level ERROR"
+    )
+    return fake_check
 
-    return fake_checks
+
+@pytest.fixture
+def fake_check_info():
+    fake_check = MagicMock()
+    fake_check.level = CheckLevel.INFO
+    fake_check.error_code = 12
+    fake_check.description.return_value = (
+        "This sample message has code 12 and level INFO"
+    )
+    return fake_check
+
+
+@pytest.fixture
+def fake_checks(fake_check_warning, fake_check_error, fake_check_info):
+    return [fake_check_warning, fake_check_error, fake_check_info]
 
 
 def test_generate_rst_table(fake_checks):


### PR DESCRIPTION
To easily collect errors in the MI with geometry I added a new exporter that returns a named tuple (`ErrorWithGeom`) that contains all information the MI needs.

Usage:
```
    modelchecker = ThreediModelChecker(schema.db)
    errors = modelchecker.errors()
    result = export_with_geom(errors)
```