### PR TITLE
Handle empty cross-section tables in record parsing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog of threedi-modelchecker
 -------------------
 
 - Fix checks 1604 and 1605 from stalling execution
+- Fix checks that fail on empty cross_section_table
 
 
 2.18.0 (2025-04-16)

--- a/threedi_modelchecker/checks/cross_section_definitions.py
+++ b/threedi_modelchecker/checks/cross_section_definitions.py
@@ -332,6 +332,10 @@ def get_widths_heights_for_tabulated_record(record):
 
 def cross_section_configuration_for_record(record):
     if record.cross_section_shape.is_tabulated:
+        # Handle empty cross section table by returning all None to prevent issues in parsing
+        # Note that CrossSectionNullCheck already checks for this
+        if record.cross_section_table is None or record.cross_section_table == "":
+            return None, None, None
         widths, heights = get_widths_heights_for_tabulated_record(record)
         return cross_section_configuration_tabulated(
             shape=record.cross_section_shape, widths=widths, heights=heights

--- a/threedi_modelchecker/tests/test_checks_cross_section_definitions.py
+++ b/threedi_modelchecker/tests/test_checks_cross_section_definitions.py
@@ -632,6 +632,16 @@ def test_cross_section_configuration_not_tabulated_raise():
             {"cross_section_width": 1, "cross_section_height": 2},
             (1, 2, "closed"),
         ),
+        (
+            constants.CrossSectionShape.TABULATED_YZ,
+            {},
+            (None, None, None),
+        ),
+        (
+            constants.CrossSectionShape.TABULATED_YZ,
+            {"cross_section_table": ""},
+            (None, None, None),
+        ),
     ],
 )
 def test_cross_section_configuration_for_record(session, shape, kwargs, expected):


### PR DESCRIPTION
### Description

This pull request addresses an issue where empty cross-section tables in `cross_section_configuration_for_record` caused parsing errors. The implementation ensures that `None` is returned for empty tables, improving the robustness of the system alongside `CrossSectionNullCheck`. Note that this issue does not exist in any other cases where `cross_section_table` is parsed because in those instances records with `None` and empty `cross_section_table` fields are filtered out. 

Additionally, a test has been added to reproduce the bug and confirm that it is resolved.

