### PR TITLE
Fix UsedSettingsPresentCheck

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog of threedi-modelchecker
 
 - Fix checks 1604 and 1605 from stalling execution
 - Fix checks that fail on empty cross_section_table
+- Fix check 0329 to only raise when none of the associated tables contain data
 
 
 2.18.0 (2025-04-16)

--- a/threedi_modelchecker/checks/other.py
+++ b/threedi_modelchecker/checks/other.py
@@ -886,9 +886,11 @@ class UsedSettingsPresentCheck(BaseCheck):
         # more than 1 row should be caught by another check
         all_results = self.to_check(session).filter(self.column == True).all()
         use_cols = len(all_results) > 0
-        for table in self.settings_tables:
-            if use_cols and session.query(table).count() == 0:
-                return all_results
+        # return as invalid if the use_col is true but none of the associated tables are actually used
+        if use_cols and all(
+            session.query(table).count() == 0 for table in self.settings_tables
+        ):
+            return all_results
         return []
 
     def description(self) -> str:

--- a/threedi_modelchecker/tests/test_checks_other.py
+++ b/threedi_modelchecker/tests/test_checks_other.py
@@ -758,7 +758,7 @@ def test_used_settings_present_check_single_table(session, use_setting, add_sett
 @pytest.mark.parametrize("add_surface", [True, False])
 @pytest.mark.parametrize("add_dwf", [True, False])
 def test_used_settings_present_check(session, use_setting, add_surface, add_dwf):
-    nof_invalid_expected = 1 if use_setting and not (add_surface and add_dwf) else 0
+    nof_invalid_expected = 1 if use_setting and not (add_surface or add_dwf) else 0
     factories.SimulationTemplateSettingsFactory(use_0d_inflow=use_setting)
     if add_surface:
         factories.SurfaceFactory()


### PR DESCRIPTION
Modified UsedSettingsPresentCheck to only raise when none of the associated settings are present