### PR TITLE
Add TimeUnitsValidCheck for timeseries validation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog of threedi-modelchecker
 
 - Fix checks 1604 and 1605 from stalling execution
 - Fix checks that fail on empty cross_section_table
+- Add check 1207 for time_units in boundary_condition_1d, boundary_condition_2d, lateral_1d and lateral_2d
 
 
 2.18.0 (2025-04-16)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,9 @@ dependencies = [
     "GeoAlchemy2>=0.9,!=0.11.*",
     "SQLAlchemy>=1.4",
     "pyproj",
-    "threedi-schema==0.300.*,>=0.300.23"
+    "pint==0.20",
+    "attrs==22.1.0; python_version < '3.12'",
+    "attrs==23.2.0; python_version >= '3.12' and python_version < '3.14'",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,6 @@ dependencies = [
     "GeoAlchemy2>=0.9,!=0.11.*",
     "SQLAlchemy>=1.4",
     "pyproj",
-    "pint==0.22",
-    "attrs==22.1.0; python_version < '3.12'",
-    "attrs==23.2.0; python_version >= '3.12' and python_version < '3.14'",
     "threedi-schema==0.300.*,>=0.300.23",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "GeoAlchemy2>=0.9,!=0.11.*",
     "SQLAlchemy>=1.4",
     "pyproj",
-    "pint==0.21",
+    "pint==0.22",
     "attrs==22.1.0; python_version < '3.12'",
     "attrs==23.2.0; python_version >= '3.12' and python_version < '3.14'",
     "threedi-schema==0.300.*,>=0.300.23",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "pint==0.20",
     "attrs==22.1.0; python_version < '3.12'",
     "attrs==23.2.0; python_version >= '3.12' and python_version < '3.14'",
+    "threedi-schema==0.300.*,>=0.300.23",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "GeoAlchemy2>=0.9,!=0.11.*",
     "SQLAlchemy>=1.4",
     "pyproj",
-    "pint==0.20",
+    "pint==0.21",
     "attrs==22.1.0; python_version < '3.12'",
     "attrs==23.2.0; python_version >= '3.12' and python_version < '3.14'",
     "threedi-schema==0.300.*,>=0.300.23",

--- a/threedi_modelchecker/checks/timeseries.py
+++ b/threedi_modelchecker/checks/timeseries.py
@@ -1,3 +1,5 @@
+from pint import UnitRegistry
+from pint.errors import UndefinedUnitError
 from threedi_schema import models
 
 from .base import BaseCheck
@@ -266,3 +268,20 @@ class TimeseriesStartsAtZeroCheck(BaseCheck):
 
     def description(self):
         return f"{self.column_name} should be start at timestamp 0"
+
+
+class TimeUnitsValidCheck(BaseCheck):
+    """Check that an empty timeseries has not been provided."""
+
+    def get_invalid(self, session):
+        invalid_rows = []
+        ureg = UnitRegistry()
+        for row in self.to_check(session).all():
+            try:
+                ureg.parse_units(row.time_units)
+            except UndefinedUnitError:
+                invalid_rows.append(row)
+        return invalid_rows
+
+    def description(self):
+        return f"{self.column_name} is not recognized as a valid unit of time."

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -104,6 +104,7 @@ from .checks.timeseries import (
     TimeseriesStartsAtZeroCheck,
     TimeseriesTimestepCheck,
     TimeseriesValueCheck,
+    TimeUnitsValidCheck,
 )
 
 TOLERANCE_M = 1.0
@@ -2872,7 +2873,15 @@ CHECKS += [
     ]
 ]
 CHECKS += [FirstTimeSeriesEqualTimestepsCheck(error_code=1206)]
-
+CHECKS += [
+    TimeUnitsValidCheck(col, error_code=1207)
+    for col in [
+        models.BoundaryCondition1D.time_units,
+        models.BoundaryConditions2D.time_units,
+        models.Lateral1D.time_units,
+        models.Lateral2D.time_units,
+    ]
+]
 
 CHECKS += [
     QueryCheck(

--- a/threedi_modelchecker/tests/test_checks_timeseries.py
+++ b/threedi_modelchecker/tests/test_checks_timeseries.py
@@ -233,7 +233,16 @@ def test_timeseries_starts_zero_check_err(session, timeseries):
     assert len(invalid) == 1
 
 
-@pytest.mark.parametrize("time_units, valid", [("seconds", True), ("foo", False)])
+@pytest.mark.parametrize(
+    "time_units, valid",
+    [
+        ("seconds", True),
+        ("Seconds", True),
+        ("minutes", True),
+        ("hours", True),
+        ("foo", False),
+    ],
+)
 def test_time_units_valid_check(session, time_units, valid):
     BoundaryConditions2DFactory(time_units=time_units)
     check = TimeUnitsValidCheck(models.BoundaryConditions2D.time_units)

--- a/threedi_modelchecker/tests/test_checks_timeseries.py
+++ b/threedi_modelchecker/tests/test_checks_timeseries.py
@@ -233,9 +233,9 @@ def test_timeseries_starts_zero_check_err(session, timeseries):
     assert len(invalid) == 1
 
 
-@pytest.mark.parametrize("time_units, valid", [("foo", False), ("seconds", True)])
+@pytest.mark.parametrize("time_units, valid", [("seconds", True), ("foo", False)])
 def test_time_units_valid_check(session, time_units, valid):
     BoundaryConditions2DFactory(time_units=time_units)
-    check = TimeUnitsValidCheck(models.BoundaryConditions2D.timeseries)
+    check = TimeUnitsValidCheck(models.BoundaryConditions2D.time_units)
     invalid = check.get_invalid(session)
     assert (len(invalid) == 0) == valid

--- a/threedi_modelchecker/tests/test_checks_timeseries.py
+++ b/threedi_modelchecker/tests/test_checks_timeseries.py
@@ -10,6 +10,7 @@ from threedi_modelchecker.checks.timeseries import (
     TimeseriesStartsAtZeroCheck,
     TimeseriesTimestepCheck,
     TimeseriesValueCheck,
+    TimeUnitsValidCheck,
 )
 
 from .factories import BoundaryConditions1DFactory, BoundaryConditions2DFactory
@@ -230,3 +231,11 @@ def test_timeseries_starts_zero_check_err(session, timeseries):
     check = TimeseriesStartsAtZeroCheck(models.BoundaryConditions2D.timeseries)
     invalid = check.get_invalid(session)
     assert len(invalid) == 1
+
+
+@pytest.mark.parametrize("time_units, valid", [("foo", False), ("seconds", True)])
+def test_time_units_valid_check(session, time_units, valid):
+    BoundaryConditions2DFactory(time_units=time_units)
+    check = TimeUnitsValidCheck(models.BoundaryConditions2D.timeseries)
+    invalid = check.get_invalid(session)
+    assert (len(invalid) == 0) == valid


### PR DESCRIPTION

Introduced `TimeUnitsValidCheck` to validate time unit formats in timeseries data against `parse_timeunits` from pint. `TimeUnitsValidCheck` is used in check 1207 for boundary_condition_1d, boundary_condition_2d, lateral_1d and lateral_2d.

