### PR TITLE
Add filter exclude embedded notes from check 45

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog of threedi-modelchecker
 2.18.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Exclude embedded nodes from check for connection node storage area (check 45)
 
 
 2.18.1 (2025-04-28)

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -427,6 +427,7 @@ CHECKS += [
                 models.ConnectionNode.storage_area < 0,
             )
         )
+        .filter(models.ConnectionNode.exchange_type != 0)
         .filter(
             models.ConnectionNode.id.notin_(
                 Query(models.Pipe.connection_node_id_start).union_all(


### PR DESCRIPTION
Tested with:

```python
def test_check_manual(session):
    factories.ModelSettingsFactory()
    factories.ConnectionNodeFactory(id=1, geom=f"SRID={SRID};POINT({POINT1})", )
    factories.ConnectionNodeFactory(id=2, geom=f"SRID={SRID};POINT({POINT1})", exchange_type=1)
    factories.ConnectionNodeFactory(id=3, geom=f"SRID={SRID};POINT({POINT1})", exchange_type=1, storage_area=0.0)
    factories.ConnectionNodeFactory(id=4, geom=f"SRID={SRID};POINT({POINT1})", exchange_type=1, storage_area=-1)
    factories.ConnectionNodeFactory(id=5, geom=f"SRID={SRID};POINT({POINT1})", exchange_type=0, storage_area=-1)
    check = QueryCheck(
        error_code=45,
        column=models.ConnectionNode.id,
        invalid=Query(models.ConnectionNode)
        .filter(
            or_(
                models.ConnectionNode.storage_area.is_(None),
                models.ConnectionNode.storage_area < 0,
            )
        )
        .filter(models.ConnectionNode.exchange_type != 0)
        .filter(
            models.ConnectionNode.id.notin_(
                Query(models.Pipe.connection_node_id_start).union_all(
                    Query(models.Pipe.connection_node_id_end),
                    Query(models.Channel.connection_node_id_start),
                    Query(models.Channel.connection_node_id_end),
                    Query(models.Culvert.connection_node_id_start),
                    Query(models.Culvert.connection_node_id_end),
                    Query(models.Weir.connection_node_id_start),
                    Query(models.Weir.connection_node_id_end),
                    Query(models.Orifice.connection_node_id_start),
                    Query(models.Orifice.connection_node_id_end),
                )
            ),
        ),
        message="connection_node.storage_area should be defined and greater than 0 if the connection nodes "
        "has no connections to channels, culverts, pipes, weirs, or orifices0. "
        "From September 2025 onwards, this will be an ERROR.",
    )
    error_ids = [item.id for item in check.get_invalid(session)]
    assert error_ids == [2, 4]
    ```
   
    (not added to the codebase)