### PR TITLE
Fix geometry exporter to handle WKB format in error rows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog of threedi-modelchecker
 2.18.4 (unreleased)
 -------------------
 
-- Prevent geometry exporter from failing when geometry in error row is already a wkb
+- Prevent geometry exporter from failing or causing downstream failues when geometry in error row is not a WKBElement
+- Fix `geom` returned with the ConnectionNodesDistance check
 
 
 2.18.3 (2025-05-08)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog of threedi-modelchecker
 2.18.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Prevent geometry exporter from failing when geometry in error row is already a wkb
 
 
 2.18.3 (2025-05-08)

--- a/threedi_modelchecker/exporters.py
+++ b/threedi_modelchecker/exporters.py
@@ -45,19 +45,29 @@ def export_with_geom(
     :return: A list of ErrorWithGeom named tuples, each containing details about the error,
     including geometry if available
     """
-    return [
-        ErrorWithGeom(
-            name=check.level.name,
-            code=check.error_code,
-            id=error_row.id,
-            table=check.table.name,
-            column=check.column.name,
-            value=getattr(error_row, check.column.name),
-            description=check.description(),
-            geom=error_row.geom.as_wkb() if hasattr(error_row, "geom") else None,
+    errors_with_geom = []
+    for check, error_row in errors:
+        if hasattr(error_row, "geom"):
+            geom = (
+                error_row.geom
+                if isinstance(error_row.geom, bytes)
+                else error_row.geom.as_wkb()
+            )
+        else:
+            geom = None
+        errors_with_geom.append(
+            ErrorWithGeom(
+                name=check.level.name,
+                code=check.error_code,
+                id=error_row.id,
+                table=check.table.name,
+                column=check.column.name,
+                value=getattr(error_row, check.column.name),
+                description=check.description(),
+                geom=geom,
+            )
         )
-        for check, error_row in errors
-    ]
+    return errors_with_geom
 
 
 def format_check_results(check: BaseCheck, invalid_row: NamedTuple):

--- a/threedi_modelchecker/exporters.py
+++ b/threedi_modelchecker/exporters.py
@@ -3,6 +3,8 @@ from collections import namedtuple
 from io import StringIO
 from typing import Iterator, NamedTuple, Tuple
 
+from geoalchemy2.elements import WKBElement
+
 from threedi_modelchecker.checks.base import BaseCheck
 
 ErrorWithGeom = namedtuple(
@@ -49,7 +51,7 @@ def export_with_geom(
     for check, error_row in errors:
         if hasattr(error_row, "geom"):
             geom = (
-                error_row.geom
+                WKBElement(error_row.geom)
                 if isinstance(error_row.geom, bytes)
                 else error_row.geom.as_wkb()
             )

--- a/threedi_modelchecker/exporters.py
+++ b/threedi_modelchecker/exporters.py
@@ -49,14 +49,9 @@ def export_with_geom(
     """
     errors_with_geom = []
     for check, error_row in errors:
-        if hasattr(error_row, "geom"):
-            geom = (
-                WKBElement(error_row.geom)
-                if isinstance(error_row.geom, bytes)
-                else error_row.geom.as_wkb()
-            )
-        else:
-            geom = None
+        geom = None
+        if hasattr(error_row, "geom") and isinstance(error_row.geom, WKBElement):
+            geom = error_row.geom
         errors_with_geom.append(
             ErrorWithGeom(
                 name=check.level.name,


### PR DESCRIPTION
- Adjusted the geometry exporter to only include geometry when it is an WKB object
- Modify ConnectionNodesDistance check to resturn a WKB object

