### PR TITLE
Add warning for settings tables that contain data but related use settings is not True

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog of threedi-modelchecker
 2.18.10 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Add warning for settings tables that contain data but related use settings is not True (#485)
 
 
 2.18.9 (2025-06-30)

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -80,6 +80,7 @@ from .checks.other import (
     SpatialIndexCheck,
     SurfaceNodeInflowAreaCheck,
     TagsValidCheck,
+    UnusedSettingsPresentCheck,
     Use0DFlowCheck,
     UsedSettingsPresentCheck,
     UsedSettingsPresentCheckSingleTable,
@@ -1702,6 +1703,25 @@ CHECKS += [
     UsedSettingsPresentCheck(
         error_code=329,
         level=CheckLevel.FUTURE_ERROR,
+        column=use_col,
+        settings_tables=tables,
+    )
+    for tables, use_col in (
+        (
+            [models.Surface, models.DryWeatherFlow],
+            models.SimulationTemplateSettings.use_0d_inflow,
+        ),
+        (
+            [models.TableControl, models.MemoryControl],
+            models.SimulationTemplateSettings.use_structure_control,
+        ),
+    )
+]
+
+CHECKS += [
+    UnusedSettingsPresentCheck(
+        error_code=330,
+        level=CheckLevel.WARNING,
         column=use_col,
         settings_tables=tables,
     )

--- a/threedi_modelchecker/tests/test_checks_other.py
+++ b/threedi_modelchecker/tests/test_checks_other.py
@@ -35,6 +35,7 @@ from threedi_modelchecker.checks.other import (
     TableControlActionTableCheckDefault,
     TableControlActionTableCheckDischargeCoefficients,
     TagsValidCheck,
+    UnusedSettingsPresentCheck,
     Use0DFlowCheck,
     UsedSettingsPresentCheck,
     UsedSettingsPresentCheckSingleTable,
@@ -765,6 +766,29 @@ def test_used_settings_present_check(session, use_setting, add_surface, add_dwf)
     if add_dwf:
         factories.DryWeatherFlowFactory()
     check = UsedSettingsPresentCheck(
+        column=models.SimulationTemplateSettings.use_0d_inflow,
+        settings_tables=[models.Surface, models.DryWeatherFlow],
+    )
+    assert len(check.get_invalid(session)) == nof_invalid_expected
+
+
+@pytest.mark.parametrize("use_setting", [True, False])
+@pytest.mark.parametrize("add_surface", [True, False])
+@pytest.mark.parametrize("add_dwf", [True, False])
+def test_unused_settings_present_check(session, use_setting, add_surface, add_dwf):
+    if use_setting:
+        nof_invalid_expected = 0
+    elif add_surface or add_dwf:
+        nof_invalid_expected = 1
+    else:
+        nof_invalid_expected = 0
+    # nof_invalid_expected = 0 if use_setting and not (add_surface or add_dwf) else 1
+    factories.SimulationTemplateSettingsFactory(use_0d_inflow=use_setting)
+    if add_surface:
+        factories.SurfaceFactory()
+    if add_dwf:
+        factories.DryWeatherFlowFactory()
+    check = UnusedSettingsPresentCheck(
         column=models.SimulationTemplateSettings.use_0d_inflow,
         settings_tables=[models.Surface, models.DryWeatherFlow],
     )


### PR DESCRIPTION

This pull request modifies the logic for checking settings' tables to handle cases where data exists but the related "use" settings are not enabled. The `UsedSettingsPresentCheck` class has been generalized and renamed to `SettingsPresentCheck`, with two derived classes, `UsedSettingsPresentCheck` and `UnusedSettingsPresentCheck`, for specific use cases.