### PR TITLE
Convert WKB value attributes to WKT

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog of threedi-modelchecker
 2.18.11 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Convert value fields, returned by export_with_geom, containing WKB to WKT
 
 
 2.18.10 (2025-07-15)

--- a/threedi_modelchecker/exporters.py
+++ b/threedi_modelchecker/exporters.py
@@ -4,6 +4,7 @@ from io import StringIO
 from typing import Iterator, NamedTuple, Tuple
 
 from geoalchemy2.elements import WKBElement
+from geoalchemy2.shape import to_shape
 
 from threedi_modelchecker.checks.base import BaseCheck
 
@@ -52,6 +53,12 @@ def export_with_geom(
         geom = None
         if hasattr(error_row, "geom") and isinstance(error_row.geom, WKBElement):
             geom = error_row.geom
+        value = getattr(error_row, check.column.name)
+        if isinstance(value, WKBElement):
+            try:
+                value = to_shape(value).wkt
+            except Exception:
+                value = None
         errors_with_geom.append(
             ErrorWithGeom(
                 name=check.level.name,
@@ -59,7 +66,7 @@ def export_with_geom(
                 id=error_row.id,
                 table=check.table.name,
                 column=check.column.name,
-                value=getattr(error_row, check.column.name),
+                value=value,
                 description=check.description(),
                 geom=geom,
             )


### PR DESCRIPTION
Convert `value` attribute to WKT string to prevent surpising when other code uses the exporters. Including this in the test required a lot of mocking because we don't have shapely in the modelchecker and I didn't want to use geoalchemy to create data.