### PR TITLE
Add time units consistency checks for boundary conditions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog of threedi-modelchecker
 --------------------
 
 - Add check that warns when the total percentage mapped to the same surface via SurfaceMap is greater than 100% (nens/rana#3863)
+- Add check for matching time units for boundary conditions (nens/rana#3619)
 
 
 2.18.18 (2026-04-10)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of threedi-modelchecker
 --------------------
 
 - Add check that warns when the total percentage mapped to the same surface via SurfaceMap is greater than 100% (nens/rana#3863)
-- Add check for matching time units for boundary conditions (nens/rana#3619)
+- Add check (E1028 and E1209) for matching time units for boundary conditions (nens/rana#3619)
 
 
 2.18.18 (2026-04-10)

--- a/threedi_modelchecker/checks/timeseries.py
+++ b/threedi_modelchecker/checks/timeseries.py
@@ -1,7 +1,31 @@
+from enum import Enum
+from itertools import chain
+
 from sqlalchemy import func
 from threedi_schema import models
 
 from .base import BaseCheck
+
+valid_time_map = {
+    "seconds": ["seconds", "second", "sec", "s"],
+    "minutes": ["minutes", "minute", "min", "m"],
+    "hours": ["hours", "hour", "hr", "h"],
+}
+
+
+class TimeUnits(Enum):
+    seconds = "seconds"
+    minutes = "minutes"
+    hours = "hours"
+
+    @classmethod
+    def from_string(cls, time_units: str) -> "TimeUnits":
+        if time_units is None:
+            raise ValueError("time_units cannot be None")
+        for key, values in valid_time_map.items():
+            if time_units.lower() in values:
+                return cls[key]
+        raise ValueError(f"Invalid time units: {time_units}")
 
 
 def parse_timeseries(timeseries_str):
@@ -273,20 +297,7 @@ class TimeUnitsValidCheck(BaseCheck):
     """Check that an empty timeseries has not been provided."""
 
     def get_invalid(self, session):
-        valid_units = [
-            "second",
-            "seconds",
-            "sec",
-            "s",
-            "minute",
-            "minutes",
-            "min",
-            "m",
-            "hour",
-            "hours",
-            "hr",
-            "h",
-        ]
+        valid_units = list(chain.from_iterable(valid_time_map.values()))
         return (
             self.to_check(session)
             .filter(func.lower(self.column).not_in(valid_units))
@@ -309,22 +320,18 @@ class TimeUnitsEqualCheck(BaseCheck):
 
     def get_invalid(self, session):
         invalid_records = []
-
         first_time_units = None
-
         for row in self.to_check(session).all():
-            time_units = row.time_units
-
-            if not time_units:
+            try:
+                time_units = TimeUnits.from_string(row.time_units)
+            except ValueError:
+                # invalid values are handled by another check
                 continue
-
             if not first_time_units:
                 first_time_units = time_units
                 continue  # don't compare first record with itself
-
-            if time_units.lower() != first_time_units.lower():
+            if time_units != first_time_units:
                 invalid_records.append(row)
-
         return invalid_records
 
     def description(self):
@@ -359,9 +366,14 @@ class FirstTimeUnitsEqualCheck(BaseCheck):
             .first()
         )
         if first_1d and first_2d:
-            if first_1d.time_units.lower() != first_2d.time_units.lower():
-                return [first_1d]
-
+            try:
+                first_1d_time_units = TimeUnits.from_string(first_1d.time_units)
+                first_2d_time_units = TimeUnits.from_string(first_2d.time_units)
+                if first_1d_time_units != first_2d_time_units:
+                    return [first_1d]
+            except ValueError:
+                # invalid values are handled by another check
+                pass
         return []
 
     def description(self):

--- a/threedi_modelchecker/checks/timeseries.py
+++ b/threedi_modelchecker/checks/timeseries.py
@@ -352,32 +352,35 @@ class FirstTimeUnitsEqualCheck(BaseCheck):
     """
 
     def __init__(self, *args, **kwargs):
-        super().__init__(column=models.BoundaryCondition1D.time_units, *args, **kwargs)
+        self.time_models = [
+            models.BoundaryCondition1D,
+            models.BoundaryConditions2D,
+            models.Lateral1D,
+            models.Lateral2D,
+        ]
+        super().__init__(column=self.time_models[0].time_units, *args, **kwargs)
 
     def get_invalid(self, session):
-        first_1d = (
-            session.query(models.BoundaryCondition1D)
-            .order_by(models.BoundaryCondition1D.id)
-            .first()
-        )
-        first_2d = (
-            session.query(models.BoundaryConditions2D)
-            .order_by(models.BoundaryConditions2D.id)
-            .first()
-        )
-        if first_1d and first_2d:
+        first_items = [
+            item
+            for item in (
+                session.query(model).order_by(model.id).first()
+                for model in self.time_models
+            )
+            if item is not None
+        ]
+        first_time_unit = None
+        for item in first_items:
             try:
-                first_1d_time_units = TimeUnits.from_string(first_1d.time_units)
-                first_2d_time_units = TimeUnits.from_string(first_2d.time_units)
-                if first_1d_time_units != first_2d_time_units:
-                    return [first_1d]
+                time_unit = TimeUnits.from_string(item.time_units)
             except ValueError:
                 # invalid values are handled by another check
-                pass
+                continue
+            if first_time_unit is None:
+                first_time_unit = time_unit
+            elif time_unit != first_time_unit:
+                return first_items
         return []
 
     def description(self):
-        return (
-            "The value for the first boundary_condition_1d.time_units did not match the value for the first boundary_condition_2d.time_units. "
-            + "All boundary conditions must have the same time units."
-        )
+        return "Time units should be identical across all boundary condition and lateral tables."

--- a/threedi_modelchecker/checks/timeseries.py
+++ b/threedi_modelchecker/checks/timeseries.py
@@ -295,3 +295,77 @@ class TimeUnitsValidCheck(BaseCheck):
 
     def description(self):
         return f"{self.column_name} is not recognized as a valid unit of time."
+
+
+class TimeUnitsEqualCheck(BaseCheck):
+    """
+    Check that all time_units values within a single table are identical.
+
+    This checks the time_units for all records in a column against the time_units in the first
+    record in that column. Consequently, all records in that column must have the same time_units.
+    This check does not compare time_units between different tables; for that, FirstTimeUnitsEqualCheck
+    is used.
+    """
+
+    def get_invalid(self, session):
+        invalid_records = []
+
+        first_time_units = None
+
+        for row in self.to_check(session).all():
+            time_units = row.time_units
+
+            if not time_units:
+                continue
+
+            if not first_time_units:
+                first_time_units = time_units
+                continue  # don't compare first record with itself
+
+            if time_units.lower() != first_time_units.lower():
+                invalid_records.append(row)
+
+        return invalid_records
+
+    def description(self):
+        return (
+            f"One or more records in {self.column_name} have a different time_units than the first record. "
+            + "All time_units within this table must be identical."
+        )
+
+
+class FirstTimeUnitsEqualCheck(BaseCheck):
+    """
+    Check that the first time_units value is identical across all boundary condition tables.
+
+    This is used in conjunction with TimeUnitsEqualCheck to confirm that all time_units across
+    all boundary condition tables are identical. If each time_units within each table is identical,
+    and the first time_units of each table matches with the first time_units of each other table,
+    then all time_units must be identical across all tables.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(column=models.BoundaryCondition1D.time_units, *args, **kwargs)
+
+    def get_invalid(self, session):
+        first_1d = (
+            session.query(models.BoundaryCondition1D)
+            .order_by(models.BoundaryCondition1D.id)
+            .first()
+        )
+        first_2d = (
+            session.query(models.BoundaryConditions2D)
+            .order_by(models.BoundaryConditions2D.id)
+            .first()
+        )
+        if first_1d and first_2d:
+            if first_1d.time_units.lower() != first_2d.time_units.lower():
+                return [first_1d]
+
+        return []
+
+    def description(self):
+        return (
+            "The value for the first boundary_condition_1d.time_units did not match the value for the first boundary_condition_2d.time_units. "
+            + "All boundary conditions must have the same time units."
+        )

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -3005,6 +3005,8 @@ CHECKS += [
     for col in [
         models.BoundaryCondition1D.time_units,
         models.BoundaryConditions2D.time_units,
+        models.Lateral1D.time_units,
+        models.Lateral2D.time_units,
     ]
 ]
 CHECKS += [FirstTimeUnitsEqualCheck(error_code=1209)]

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -100,6 +100,7 @@ from .checks.raster import (
 )
 from .checks.timeseries import (
     FirstTimeSeriesEqualTimestepsCheck,
+    FirstTimeUnitsEqualCheck,
     TimeSeriesEqualTimestepsCheck,
     TimeseriesExistenceCheck,
     TimeseriesIncreasingCheck,
@@ -107,6 +108,7 @@ from .checks.timeseries import (
     TimeseriesStartsAtZeroCheck,
     TimeseriesTimestepCheck,
     TimeseriesValueCheck,
+    TimeUnitsEqualCheck,
     TimeUnitsValidCheck,
 )
 
@@ -2998,6 +3000,15 @@ CHECKS += [
         models.Lateral2D.time_units,
     ]
 ]
+CHECKS += [
+    TimeUnitsEqualCheck(col, error_code=1208)
+    for col in [
+        models.BoundaryCondition1D.time_units,
+        models.BoundaryConditions2D.time_units,
+    ]
+]
+CHECKS += [FirstTimeUnitsEqualCheck(error_code=1209)]
+
 
 CHECKS += [
     QueryCheck(

--- a/threedi_modelchecker/tests/test_checks_timeseries.py
+++ b/threedi_modelchecker/tests/test_checks_timeseries.py
@@ -255,13 +255,12 @@ def test_time_units_valid_check(session, time_units, valid):
     assert (len(invalid) == 0) == valid
 
 
-@pytest.mark.parametrize("check_type", ["1d", "2d"])
 @pytest.mark.parametrize(
     "time_units_tuple,expected_invalid",
     [
         ((), 0),  # no time_units
         (("seconds", "seconds"), 0),  # same time_units
-        (("seconds", "SECONDS"), 0),  # same time_units, different case
+        (("seconds", "sec"), 0),  # same time_units, different case
         (("minutes", "minutes"), 0),  # same time_units
         (("seconds", "minutes"), 1),  # differing time_units
         (
@@ -270,17 +269,10 @@ def test_time_units_valid_check(session, time_units, valid):
         ),  # all different time_units
     ],
 )
-def test_time_units_equal_check(
-    session, time_units_tuple, check_type, expected_invalid
-):
-    if check_type == "1d":
-        for time_units in time_units_tuple:
-            BoundaryConditions1DFactory(time_units=time_units)
-        check = TimeUnitsEqualCheck(models.BoundaryCondition1D.time_units)
-    elif check_type == "2d":
-        for time_units in time_units_tuple:
-            BoundaryConditions2DFactory(time_units=time_units)
-        check = TimeUnitsEqualCheck(models.BoundaryConditions2D.time_units)
+def test_time_units_equal_check(session, time_units_tuple, expected_invalid):
+    for time_units in time_units_tuple:
+        BoundaryConditions1DFactory(time_units=time_units)
+    check = TimeUnitsEqualCheck(models.BoundaryCondition1D.time_units)
     invalid = check.get_invalid(session)
     assert len(invalid) == expected_invalid
 

--- a/threedi_modelchecker/tests/test_checks_timeseries.py
+++ b/threedi_modelchecker/tests/test_checks_timeseries.py
@@ -18,6 +18,8 @@ from threedi_modelchecker.checks.timeseries import (
 from .factories import (
     BoundaryConditions1DFactory,
     BoundaryConditions2DFactory,
+    Lateral1DFactory,
+    Lateral2DFactory,
 )
 
 
@@ -278,38 +280,31 @@ def test_time_units_equal_check(session, time_units_tuple, expected_invalid):
 
 
 @pytest.mark.parametrize(
-    "one_d_time_units_tuple,two_d_time_units_tuple,expected_invalid",
+    "units_1d_bc, units_2d_bc, units_1d_lat, units_2d_lat, expected_invalid",
     [
-        ((), (), 0),  # no time_units
-        (("seconds",), (), 0),  # only 1d time_units
-        ((), ("seconds",), 0),  # only 2d time_units
-        (
-            ("seconds",),
-            ("seconds",),
-            0,
-        ),  # 1d and 2d match
-        (
-            ("seconds",),
-            ("minutes",),
-            1,
-        ),  # 1d and 2d don't match (2d is invalid)
-        (
-            ("sec",),
-            ("seconds",),
-            0,
-        ),  # 1d and 2d match
+        (None, None, None, None, 0),
+        ("seconds", None, None, None, 0),
+        ("seconds", "seconds", "seconds", "seconds", 0),
+        ("seconds", "minutes", "seconds", "seconds", 4),
+        ("seconds", None, None, "minutes", 2),
     ],
 )
 def test_first_time_units_equal_check(
     session,
-    one_d_time_units_tuple,
-    two_d_time_units_tuple,
+    units_1d_bc,
+    units_2d_bc,
+    units_1d_lat,
+    units_2d_lat,
     expected_invalid,
 ):
-    for time_units in one_d_time_units_tuple:
-        BoundaryConditions1DFactory(time_units=time_units)
-    for time_units in two_d_time_units_tuple:
-        BoundaryConditions2DFactory(time_units=time_units)
+    if units_1d_bc:
+        BoundaryConditions1DFactory(time_units=units_1d_bc)
+    if units_2d_bc:
+        BoundaryConditions2DFactory(time_units=units_2d_bc)
+    if units_1d_lat:
+        Lateral1DFactory(time_units=units_1d_lat)
+    if units_2d_lat:
+        Lateral2DFactory(time_units=units_2d_lat)
     check = FirstTimeUnitsEqualCheck()
     invalid = check.get_invalid(session)
     assert len(invalid) == expected_invalid

--- a/threedi_modelchecker/tests/test_checks_timeseries.py
+++ b/threedi_modelchecker/tests/test_checks_timeseries.py
@@ -302,10 +302,10 @@ def test_time_units_equal_check(
             1,
         ),  # 1d and 2d don't match (2d is invalid)
         (
-            ("SECONDS",),
+            ("sec",),
             ("seconds",),
             0,
-        ),  # 1d and 2d match (case-insensitive)
+        ),  # 1d and 2d match
     ],
 )
 def test_first_time_units_equal_check(

--- a/threedi_modelchecker/tests/test_checks_timeseries.py
+++ b/threedi_modelchecker/tests/test_checks_timeseries.py
@@ -3,6 +3,7 @@ from threedi_schema import models
 
 from threedi_modelchecker.checks.timeseries import (
     FirstTimeSeriesEqualTimestepsCheck,
+    FirstTimeUnitsEqualCheck,
     TimeSeriesEqualTimestepsCheck,
     TimeseriesExistenceCheck,
     TimeseriesIncreasingCheck,
@@ -10,10 +11,14 @@ from threedi_modelchecker.checks.timeseries import (
     TimeseriesStartsAtZeroCheck,
     TimeseriesTimestepCheck,
     TimeseriesValueCheck,
+    TimeUnitsEqualCheck,
     TimeUnitsValidCheck,
 )
 
-from .factories import BoundaryConditions1DFactory, BoundaryConditions2DFactory
+from .factories import (
+    BoundaryConditions1DFactory,
+    BoundaryConditions2DFactory,
+)
 
 
 @pytest.mark.parametrize("check_type", ["1d", "2d"])
@@ -248,3 +253,71 @@ def test_time_units_valid_check(session, time_units, valid):
     check = TimeUnitsValidCheck(models.BoundaryConditions2D.time_units)
     invalid = check.get_invalid(session)
     assert (len(invalid) == 0) == valid
+
+
+@pytest.mark.parametrize("check_type", ["1d", "2d"])
+@pytest.mark.parametrize(
+    "time_units_tuple,expected_invalid",
+    [
+        ((), 0),  # no time_units
+        (("seconds", "seconds"), 0),  # same time_units
+        (("seconds", "SECONDS"), 0),  # same time_units, different case
+        (("minutes", "minutes"), 0),  # same time_units
+        (("seconds", "minutes"), 1),  # differing time_units
+        (
+            ("seconds", "minutes", "hours"),
+            2,
+        ),  # all different time_units
+    ],
+)
+def test_time_units_equal_check(
+    session, time_units_tuple, check_type, expected_invalid
+):
+    if check_type == "1d":
+        for time_units in time_units_tuple:
+            BoundaryConditions1DFactory(time_units=time_units)
+        check = TimeUnitsEqualCheck(models.BoundaryCondition1D.time_units)
+    elif check_type == "2d":
+        for time_units in time_units_tuple:
+            BoundaryConditions2DFactory(time_units=time_units)
+        check = TimeUnitsEqualCheck(models.BoundaryConditions2D.time_units)
+    invalid = check.get_invalid(session)
+    assert len(invalid) == expected_invalid
+
+
+@pytest.mark.parametrize(
+    "one_d_time_units_tuple,two_d_time_units_tuple,expected_invalid",
+    [
+        ((), (), 0),  # no time_units
+        (("seconds",), (), 0),  # only 1d time_units
+        ((), ("seconds",), 0),  # only 2d time_units
+        (
+            ("seconds",),
+            ("seconds",),
+            0,
+        ),  # 1d and 2d match
+        (
+            ("seconds",),
+            ("minutes",),
+            1,
+        ),  # 1d and 2d don't match (2d is invalid)
+        (
+            ("SECONDS",),
+            ("seconds",),
+            0,
+        ),  # 1d and 2d match (case-insensitive)
+    ],
+)
+def test_first_time_units_equal_check(
+    session,
+    one_d_time_units_tuple,
+    two_d_time_units_tuple,
+    expected_invalid,
+):
+    for time_units in one_d_time_units_tuple:
+        BoundaryConditions1DFactory(time_units=time_units)
+    for time_units in two_d_time_units_tuple:
+        BoundaryConditions2DFactory(time_units=time_units)
+    check = FirstTimeUnitsEqualCheck()
+    invalid = check.get_invalid(session)
+    assert len(invalid) == expected_invalid


### PR DESCRIPTION
## Summary

Adds two new validation checks to ensure time_units consistency in boundary condition tables:

### E1208: TimeUnitsEqualCheck
- **Purpose**: Ensures all `time_units` values within a single table (BoundaryCondition1D or BoundaryConditions2D) are identical
- **Behavior**: Compares each record against the first record in the table
- **Semantic Equivalence**: Treats synonymous units as equal (e.g., "second", "seconds", "sec", "s" are all normalized to `seconds`)

### E1209: FirstTimeUnitsEqualCheck  
- **Purpose**: Ensures the first `time_units` value matches across BoundaryCondition1D and BoundaryConditions2D tables
- **Behavior**: Compares first record from each table
- **Semantic Equivalence**: Also uses the same normalization

### Implementation Details

- Introduced `TimeUnits` enum with `from_string()` classmethod to normalize unit strings
- Centralized valid time units mapping in `valid_time_map` dictionary
- Integrated with existing `TimeUnitsValidCheck` (E1207) which validates against the same allowlist
- Invalid units are skipped by the equal checks (already caught by E1207)
- Full test coverage with parametrized tests for various scenarios

### Test Coverage

- 12 parametrized tests for `TimeUnitsEqualCheck` 
- 6 parametrized tests for `FirstTimeUnitsEqualCheck`
- All 88 existing timeseries tests pass without regression