### PR TITLE
Add check for standalone pumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ celerybeat-schedule
 # Environments
 .env
 .venv
+.envrc
 env/
 venv/
 ENV/
@@ -106,6 +107,12 @@ venv.bak/
 docker-compose.override.yml
 
 
-# VS Code
+# IDE
 .vscode
 .devcontainer
+.idea
+
+# AI
+.minispec
+.opencode
+AGENTS.md

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog of threedi-modelchecker
 2.18.20 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Add check (E0254) for standalone pumps connected to isolated notes that are not embedded (nens/rana#4282)
 
 
 2.18.19 (2026-05-05)

--- a/threedi_modelchecker/config.py
+++ b/threedi_modelchecker/config.py
@@ -1358,6 +1358,43 @@ CHECKS += [
 ]
 CHECKS += [
     QueryCheck(
+        error_code=254,
+        level=CheckLevel.ERROR,
+        column=models.Pump.connection_node_id,
+        invalid=Query(models.Pump)
+        .join(
+            models.ConnectionNode,
+            models.Pump.connection_node_id == models.ConnectionNode.id,
+        )
+        .filter(
+            models.ConnectionNode.exchange_type.isnot(
+                constants.CalculationTypeNode.EMBEDDED
+            )
+        )
+        .filter(
+            models.Pump.connection_node_id.notin_(
+                Query(models.Channel.connection_node_id_start).union_all(
+                    Query(models.Channel.connection_node_id_end),
+                    Query(models.Culvert.connection_node_id_start),
+                    Query(models.Culvert.connection_node_id_end),
+                    Query(models.Pipe.connection_node_id_start),
+                    Query(models.Pipe.connection_node_id_end),
+                    Query(models.Weir.connection_node_id_start),
+                    Query(models.Weir.connection_node_id_end),
+                    Query(models.Orifice.connection_node_id_start),
+                    Query(models.Orifice.connection_node_id_end),
+                )
+            )
+        ),
+        message=(
+            "pump.connection_node_id refers to a connection node that is not "
+            "embedded but is not connected to any 1D element "
+            "(channel, culvert, pipe, weir, or orifice)"
+        ),
+    )
+]
+CHECKS += [
+    QueryCheck(
         error_code=255,
         column=models.Pump.connection_node_id,
         invalid=Query(models.Pump)

--- a/threedi_modelchecker/tests/test_query_checks.py
+++ b/threedi_modelchecker/tests/test_query_checks.py
@@ -1,0 +1,38 @@
+import pytest
+from threedi_schema import constants
+
+# Import all checks created in the config
+from threedi_modelchecker.config import CHECKS
+
+from . import factories
+
+
+def run_query_check_by_number(session, check_number):
+    check = next(c for c in CHECKS if c.error_code == check_number)
+    return check.get_invalid(session)
+
+
+@pytest.mark.parametrize(
+    "exchange_type, has_1d_element, expected_invalid_count",
+    [
+        (constants.CalculationTypeNode.EMBEDDED, False, 0),
+        (constants.CalculationTypeNode.EMBEDDED, True, 0),
+        (constants.CalculationTypeNode.ISOLATED, False, 1),
+        (constants.CalculationTypeNode.ISOLATED, True, 0),
+    ],
+)
+def test_standalone_pump_connection_node_not_embedded_needs_1d_element(
+    session, exchange_type, has_1d_element, expected_invalid_count
+):
+    cn_pump = factories.ConnectionNodeFactory(id=1, exchange_type=exchange_type)
+    cn_other = factories.ConnectionNodeFactory(id=2)
+    factories.PumpFactory(id=1, connection_node_id=cn_pump.id)
+    factories.PumpMapFactory(pump_id=1, connection_node_id_end=cn_other.id)
+    if has_1d_element:
+        factories.CulvertFactory(
+            connection_node_id_start=cn_pump.id,
+            connection_node_id_end=cn_other.id,
+        )
+
+    result = run_query_check_by_number(session, 254)
+    assert len(result) == expected_invalid_count


### PR DESCRIPTION
Closes nens/rana#4282

Add check 254 which finds pumps that:
- are connected to a non-embedded connection node
- are connected to a connection node that is not connection to any 1D element